### PR TITLE
Fix RemoteAddr

### DIFF
--- a/x/arkeo/keeper/keeper.go
+++ b/x/arkeo/keeper/keeper.go
@@ -82,7 +82,6 @@ type KeeperContract interface {
 	SetContract(_ cosmos.Context, _ types.Contract) error
 	ContractExists(_ cosmos.Context, _ common.PubKey, _ common.Chain, _ common.PubKey) bool
 	RemoveContract(_ cosmos.Context, _ common.PubKey, _ common.Chain, _ common.PubKey)
-
 	GetContractExpirationSetIterator(_ cosmos.Context) cosmos.Iterator
 	GetContractExpirationSet(_ cosmos.Context, _ int64) (types.ContractExpirationSet, error)
 	SetContractExpirationSet(_ cosmos.Context, _ types.ContractExpirationSet) error

--- a/x/claim/client/cli/tx.go
+++ b/x/claim/client/cli/tx.go
@@ -10,9 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 )
 
-var (
-	DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
-)
+var DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
 
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd() *cobra.Command {

--- a/x/claim/module_simulation.go
+++ b/x/claim/module_simulation.go
@@ -52,7 +52,6 @@ func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedP
 
 // RandomizedParams creates randomized  param changes for the simulator
 func (am AppModule) RandomizedParams(_ *rand.Rand) []simtypes.ParamChange {
-
 	return []simtypes.ParamChange{}
 }
 


### PR DESCRIPTION
RemoteAddr is not always given you the correct IP address , if the end user is sitting behind a NAT/Proxy , then it will only see the proxy's IP address.

Also , if sentinel is deployed behind a load balancer , then it will only see the load balancer's ip.

We check `X-Real-Ip` , `X-Forward-For` , and if these two are both empty , then use `RemoteAddr` from http