### PR TITLE
Claim arkeo when claiming from ETH

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -21,5 +21,6 @@ lint:
         - "ts-client"
         - "docs"
         - "config.yml"
+        - "x/claim/docs/**"
     - linters:
         - prettier

--- a/app/app.go
+++ b/app/app.go
@@ -511,7 +511,7 @@ func New(
 	)
 	arkeoModule := arkeomodule.NewAppModule(appCodec, app.ArkeoKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
 
-	app.ClaimKeeper = *claimmodulekeeper.NewKeeper(
+	app.ClaimKeeper = claimmodulekeeper.NewKeeper(
 		appCodec,
 		keys[claimmoduletypes.StoreKey],
 		app.AccountKeeper,

--- a/app/app.go
+++ b/app/app.go
@@ -514,6 +514,8 @@ func New(
 	app.ClaimKeeper = *claimmodulekeeper.NewKeeper(
 		appCodec,
 		keys[claimmoduletypes.StoreKey],
+		app.AccountKeeper,
+		app.BankKeeper,
 		keys[claimmoduletypes.MemStoreKey],
 		app.GetSubspace(claimmoduletypes.ModuleName),
 	)

--- a/proto/arkeo/claim/claim_record.proto
+++ b/proto/arkeo/claim/claim_record.proto
@@ -40,8 +40,7 @@ message ClaimRecord {
   string address = 2 [ (gogoproto.moretags) = "yaml:\"address\"" ];
 
   // total initial claimable amount for the user
-  repeated cosmos.base.v1beta1.Coin initial_claimable_amount = 3 [
-    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins",
+  cosmos.base.v1beta1.Coin initial_claimable_amount = 3 [
     (gogoproto.nullable) = false,
     (gogoproto.moretags) = "yaml:\"initial_claimable_amount\""
   ];

--- a/proto/arkeo/claim/claim_record.proto
+++ b/proto/arkeo/claim/claim_record.proto
@@ -10,8 +10,9 @@ option go_package = "github.com/arkeonetwork/arkeo/x/claim/types";
 enum Action {
   option (gogoproto.goproto_enum_prefix) = false;
 
-  ACTION_VOTE = 0;
-  ACTION_DELEGATE_STAKE = 1;
+  ACTION_CLAIM = 0;
+  ACTION_VOTE = 1;
+  ACTION_DELEGATE_STAKE = 2;
 }
 
 // actions for chains other than arkeo, limited currently to claiming

--- a/proto/arkeo/claim/genesis.proto
+++ b/proto/arkeo/claim/genesis.proto
@@ -3,10 +3,25 @@ package arkeonetwork.arkeo.claim;
 
 import "gogoproto/gogo.proto";
 import "arkeo/claim/params.proto";
+import "arkeo/claim/claim_record.proto";
+import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/arkeonetwork/arkeo/x/claim/types";
 
 // GenesisState defines the claim module's genesis state.
 message GenesisState {
-  Params params = 1 [(gogoproto.nullable) = false];
+  
+  // balance of the claim module's account
+  cosmos.base.v1beta1.Coin module_account_balance = 1 [
+    (gogoproto.moretags) = "yaml:\"module_account_balance\"",
+    (gogoproto.nullable) = false
+  ];
+  
+  Params params = 2 [(gogoproto.nullable) = false];
+
+  // list of claim records, one for every airdrop recipient
+  repeated ClaimRecord claim_records = 3 [
+    (gogoproto.moretags) = "yaml:\"claim_records\"",
+    (gogoproto.nullable) = false
+  ];
 }

--- a/proto/arkeo/claim/params.proto
+++ b/proto/arkeo/claim/params.proto
@@ -4,6 +4,7 @@ package arkeonetwork.arkeo.claim;
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
+import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/arkeonetwork/arkeo/x/claim/types";
 
@@ -26,6 +27,10 @@ message Params {
     (gogoproto.jsontag) = "duration_of_decay,omitempty",
     (gogoproto.moretags) = "yaml:\"duration_of_decay\""
   ];
+
   // denom of claimable asset
   string claim_denom = 4;  
+  // uarkeo to distribute to arkeo account for gas to make claiming easier
+  cosmos.base.v1beta1.Coin initial_gas_amount = 5  [ (gogoproto.moretags) = "yaml:\"initial_gas_amount\""];
+  ;
 }

--- a/testutil/keeper/arkeo.go
+++ b/testutil/keeper/arkeo.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/arkeonetwork/arkeo/common/cosmos"
+	"github.com/arkeonetwork/arkeo/testutil/utils"
 	"github.com/arkeonetwork/arkeo/x/arkeo/keeper"
 	"github.com/arkeonetwork/arkeo/x/arkeo/types"
 
@@ -33,17 +34,6 @@ import (
 	tmdb "github.com/tendermint/tm-db"
 )
 
-// create a codec used only for testing
-func MakeTestCodec() *codec.LegacyAmino {
-	cdc := codec.NewLegacyAmino()
-	banktypes.RegisterLegacyAminoCodec(cdc)
-	authtypes.RegisterLegacyAminoCodec(cdc)
-	types.RegisterCodec(cdc)
-	cosmos.RegisterCodec(cdc)
-	// codec.RegisterCrypto(cdc)
-	return cdc
-}
-
 func ArkeoKeeper(t testing.TB) (cosmos.Context, keeper.Keeper) {
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	keyAcc := cosmos.NewKVStoreKey(authtypes.StoreKey)
@@ -61,7 +51,7 @@ func ArkeoKeeper(t testing.TB) (cosmos.Context, keeper.Keeper) {
 
 	registry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(registry)
-	legacyCodec := MakeTestCodec()
+	legacyCodec := utils.MakeTestCodec()
 
 	paramsSubspace := typesparams.NewSubspace(cdc,
 		types.Amino,

--- a/testutil/keeper/claim.go
+++ b/testutil/keeper/claim.go
@@ -40,6 +40,10 @@ func ClaimKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	stateStore := store.NewCommitMultiStore(db)
 	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
 	stateStore.MountStoreWithDB(memStoreKey, storetypes.StoreTypeMemory, nil)
+	stateStore.MountStoreWithDB(keyAcc, storetypes.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(keyBank, storetypes.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(tkeyParams, storetypes.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(keyParams, storetypes.StoreTypeIAVL, db)
 	require.NoError(t, stateStore.LoadLatestVersion())
 
 	registry := codectypes.NewInterfaceRegistry()
@@ -77,7 +81,7 @@ func ClaimKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 
 	// Initialize params
 
-	airdropStartTime := time.Now()
+	airdropStartTime := time.Now().UTC()
 	params := types.Params{
 		AirdropStartTime:   airdropStartTime,
 		DurationUntilDecay: types.DefaultDurationUntilDecay,

--- a/testutil/keeper/claim.go
+++ b/testutil/keeper/claim.go
@@ -28,7 +28,7 @@ import (
 	tmdb "github.com/tendermint/tm-db"
 )
 
-func ClaimKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
+func ClaimKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	keyAcc := sdk.NewKVStoreKey(authtypes.StoreKey)
 	keyBank := sdk.NewKVStoreKey(banktypes.StoreKey)

--- a/testutil/keeper/claim.go
+++ b/testutil/keeper/claim.go
@@ -78,10 +78,10 @@ func ClaimKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	)
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
-
+	ctx = ctx.WithBlockTime(time.Now().UTC()) // needed for airdrop start time
 	// Initialize params
 
-	airdropStartTime := time.Now().UTC()
+	airdropStartTime := time.Now().UTC().Add(-time.Hour) // started an hour ago
 	params := types.Params{
 		AirdropStartTime:   airdropStartTime,
 		DurationUntilDecay: types.DefaultDurationUntilDecay,

--- a/testutil/utils/utils.go
+++ b/testutil/utils/utils.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"github.com/arkeonetwork/arkeo/common/cosmos"
+	"github.com/arkeonetwork/arkeo/x/arkeo/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+// create a codec used only for testing
+func MakeTestCodec() *codec.LegacyAmino {
+	cdc := codec.NewLegacyAmino()
+	banktypes.RegisterLegacyAminoCodec(cdc)
+	authtypes.RegisterLegacyAminoCodec(cdc)
+	types.RegisterCodec(cdc)
+	cosmos.RegisterCodec(cdc)
+	// codec.RegisterCrypto(cdc)
+	return cdc
+}

--- a/testutil/utils/utils.go
+++ b/testutil/utils/utils.go
@@ -4,8 +4,10 @@ import (
 	"github.com/arkeonetwork/arkeo/common/cosmos"
 	"github.com/arkeonetwork/arkeo/x/arkeo/types"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
 )
 
 // create a codec used only for testing
@@ -17,4 +19,9 @@ func MakeTestCodec() *codec.LegacyAmino {
 	cosmos.RegisterCodec(cdc)
 	// codec.RegisterCrypto(cdc)
 	return cdc
+}
+
+// GetRandomArkeoAddress returns a random arkeo address for testing
+func GetRandomArkeoAddress() sdk.AccAddress {
+	return sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 }

--- a/x/claim/docs/01_concepts.md
+++ b/x/claim/docs/01_concepts.md
@@ -4,18 +4,17 @@ order: 1
 
 # Concepts
 
-Arkeo will facilitate an airdrop to multiple communities and user groups as outlined [here]( https://www.notion.so/shapeshift/Arkeo-Airdrop-Spec-7d4abec5aa9444399b51a5ddb99a3a54)
+Arkeo will facilitate an airdrop to multiple communities and user groups as outlined [here](https://www.notion.so/shapeshift/Arkeo-Airdrop-Spec-7d4abec5aa9444399b51a5ddb99a3a54)
 
+Users are required to take multiple actions in order to recieve the full amount of their airdrop.
 
-Users are required to take multiple actions in order to recieve the full amount of their airdrop. 
+- 1/3 is sent to users when they claim their airdop
+- 1/3 is send to users after they delegate arkeo tokens to a validator
+- 1/3 is sent to users after they have voted in governance
 
-* 1/3 is sent to users when they claim their airdop
-* 1/3 is send to users after they delegate arkeo tokens to a validator
-* 1/3 is sent to users after they have voted in governance
+Users of chains with differing address structures or derivation paths, specifically ethereum and thorchain, will be able to claim on arkeo using a signed message that transfers their airdrop from the designated Ethereum or Thorchain address to their Arkeo address.
 
-Users of chains with differing address structures or derivation paths, specifically ethereum and thorchain, will be able to claim on arkeo using a signed message that transfers their airdrop from the designated Ethereum or Thorchain address to their Arkeo address. 
-
-Addresses eligible for native claims on Arkeo, will have a small amount of Arkeo in their accounts on genesis.  This will be enough to pay for the gas fees of claiming their initial airdrop. 
+Addresses eligible for native claims on Arkeo, will have a small amount of Arkeo in their accounts on genesis. This will be enough to pay for the gas fees of claiming their initial airdrop.
 
 To incentivize users to claim in a timely manner, the amount of claimable airdrop reduces over time. Users can claim the full airdrop amount for three months (`DurationUntilDecay`).
 After three months, the claimable amount linearly decays until 6 months after launch. (At which point none of it is claimable) This is controlled by the parameter `DurationOfDecay` in the code, which is set to 3 months. (6 months - 3 months).

--- a/x/claim/docs/01_concepts.md
+++ b/x/claim/docs/01_concepts.md
@@ -1,0 +1,23 @@
+<!--
+order: 1
+-->
+
+# Concepts
+
+Arkeo will facilitate an airdrop to multiple communities and user groups as outlined [here]( https://www.notion.so/shapeshift/Arkeo-Airdrop-Spec-7d4abec5aa9444399b51a5ddb99a3a54)
+
+
+Users are required to take multiple actions in order to recieve the full amount of their airdrop. 
+
+* 1/3 is sent to users when they claim their airdop
+* 1/3 is send to users after they delegate arkeo tokens to a validator
+* 1/3 is sent to users after they have voted in governance
+
+Users of chains with differing address structures or derivation paths, specifically ethereum and thorchain, will be able to claim on arkeo using a signed message that transfers their airdrop from the designated Ethereum or Thorchain address to their Arkeo address. 
+
+Addresses eligible for native claims on Arkeo, will have a small amount of Arkeo in their accounts on genesis.  This will be enough to pay for the gas fees of claiming their initial airdrop. 
+
+To incentivize users to claim in a timely manner, the amount of claimable airdrop reduces over time. Users can claim the full airdrop amount for three months (`DurationUntilDecay`).
+After three months, the claimable amount linearly decays until 6 months after launch. (At which point none of it is claimable) This is controlled by the parameter `DurationOfDecay` in the code, which is set to 3 months. (6 months - 3 months).
+
+After 6 months from launch, all unclaimed airdrop tokens are sent back to the community pool.

--- a/x/claim/docs/02_state.md
+++ b/x/claim/docs/02_state.md
@@ -1,0 +1,53 @@
+<!--
+order: 2
+-->
+
+# State
+
+### Claim Records
+
+```protobuf
+// A Claim Records is the metadata of claim data per address
+message ClaimRecord {
+
+  Chain chain = 1;
+
+  // arkeo address of claim user
+  string address = 2 [ (gogoproto.moretags) = "yaml:\"address\"" ];
+
+  // total initial claimable amount for the user
+  cosmos.base.v1beta1.Coin initial_claimable_amount = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.moretags) = "yaml:\"initial_claimable_amount\""
+  ];
+
+  // true if action is completed
+  // index of bool in array refers to action enum #
+  repeated bool action_completed = 4 [ (gogoproto.moretags) = "yaml:\"action_completed\"" ];
+}
+```
+ClaimRecords will be populated on genesis for all users and updated as a users takes actions to recieve additional airdrop tokens.
+
+### State
+
+```protobuf
+// GenesisState defines the claim module's genesis state.
+message GenesisState {
+  
+  // balance of the claim module's account
+  cosmos.base.v1beta1.Coin module_account_balance = 1 [
+    (gogoproto.moretags) = "yaml:\"module_account_balance\"",
+    (gogoproto.nullable) = false
+  ];
+  
+  Params params = 2 [(gogoproto.nullable) = false];
+
+  // list of claim records, one for every airdrop recipient
+  repeated ClaimRecord claim_records = 3 [
+    (gogoproto.moretags) = "yaml:\"claim_records\"",
+    (gogoproto.nullable) = false
+  ];
+}
+```
+
+Claim module's state consists of `params`, `claim_records`, and `module_account_balance`.

--- a/x/claim/docs/02_state.md
+++ b/x/claim/docs/02_state.md
@@ -26,6 +26,7 @@ message ClaimRecord {
   repeated bool action_completed = 4 [ (gogoproto.moretags) = "yaml:\"action_completed\"" ];
 }
 ```
+
 ClaimRecords will be populated on genesis for all users and updated as a users takes actions to recieve additional airdrop tokens.
 
 ### State
@@ -33,13 +34,13 @@ ClaimRecords will be populated on genesis for all users and updated as a users t
 ```protobuf
 // GenesisState defines the claim module's genesis state.
 message GenesisState {
-  
+
   // balance of the claim module's account
   cosmos.base.v1beta1.Coin module_account_balance = 1 [
     (gogoproto.moretags) = "yaml:\"module_account_balance\"",
     (gogoproto.nullable) = false
   ];
-  
+
   Params params = 2 [(gogoproto.nullable) = false];
 
   // list of claim records, one for every airdrop recipient

--- a/x/claim/docs/03_events.md
+++ b/x/claim/docs/03_events.md
@@ -13,13 +13,12 @@ order: 3
 | claim | sender        | {receiver}      |
 | claim | amount        | {claim_amount}  |
 
-
-| Type  | Attribute Key | Attribute Value |
-| ----- | ------------- | --------------- |
+| Type           | Attribute Key | Attribute Value |
+| -------------- | ------------- | --------------- |
 | claim_from_eth | sender        | {receiver}      |
 | claim_from_eth | amount        | {claim_amount}  |
 
-| Type  | Attribute Key | Attribute Value |
-| ----- | ------------- | --------------- |
+| Type                 | Attribute Key | Attribute Value |
+| -------------------- | ------------- | --------------- |
 | claim_from_thorchain | sender        | {receiver}      |
 | claim_from_thorchain | amount        | {claim_amount}  |

--- a/x/claim/docs/03_events.md
+++ b/x/claim/docs/03_events.md
@@ -1,0 +1,25 @@
+<!--
+order: 3
+-->
+
+# Events
+
+## External module hooks
+
+`claim` module emits one of the following events upon claiming:
+
+| Type  | Attribute Key | Attribute Value |
+| ----- | ------------- | --------------- |
+| claim | sender        | {receiver}      |
+| claim | amount        | {claim_amount}  |
+
+
+| Type  | Attribute Key | Attribute Value |
+| ----- | ------------- | --------------- |
+| claim_from_eth | sender        | {receiver}      |
+| claim_from_eth | amount        | {claim_amount}  |
+
+| Type  | Attribute Key | Attribute Value |
+| ----- | ------------- | --------------- |
+| claim_from_thorchain | sender        | {receiver}      |
+| claim_from_thorchain | amount        | {claim_amount}  |

--- a/x/claim/docs/04_hooks.md
+++ b/x/claim/docs/04_hooks.md
@@ -1,0 +1,14 @@
+<!--
+order: 5
+-->
+
+# Event Hooks
+
+Claim module reacts on following hooks of external modules.
+
+1/3 of airdrop is given when `staking.AfterDelegationModified` hook is triggered.
+1/3 of airdrop is given when `governance.AfterProposalVote` hook is triggered.
+
+Note: the first 1/3 of the airdrop is available upon the user claiming.
+
+Once the airdrop is claimed for a specific action, it can't be claimed again

--- a/x/claim/docs/05_params.md
+++ b/x/claim/docs/05_params.md
@@ -29,7 +29,7 @@ message Params {
   ];
 
   // denom of claimable asset
-  string claim_denom = 4;  
+  string claim_denom = 4;
   // uarkeo to distribute to arkeo account for gas to make claiming easier
   cosmos.base.v1beta1.Coin initial_gas_amount = 5  [ (gogoproto.moretags) = "yaml:\"initial_gas_amount\""];
   ;

--- a/x/claim/docs/05_params.md
+++ b/x/claim/docs/05_params.md
@@ -1,0 +1,43 @@
+<!--
+order: 7
+-->
+
+# Params
+
+Claim module provides below params
+
+```protobuf
+
+// Params defines the parameters for the module.
+message Params {
+  google.protobuf.Timestamp airdrop_start_time = 1 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false,
+    (gogoproto.moretags) = "yaml:\"airdrop_start_time\""
+  ];
+  google.protobuf.Duration duration_until_decay = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.stdduration) = true,
+    (gogoproto.jsontag) = "duration_until_decay,omitempty",
+    (gogoproto.moretags) = "yaml:\"duration_until_decay\""
+  ];
+  google.protobuf.Duration duration_of_decay = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.stdduration) = true,
+    (gogoproto.jsontag) = "duration_of_decay,omitempty",
+    (gogoproto.moretags) = "yaml:\"duration_of_decay\""
+  ];
+
+  // denom of claimable asset
+  string claim_denom = 4;  
+  // uarkeo to distribute to arkeo account for gas to make claiming easier
+  cosmos.base.v1beta1.Coin initial_gas_amount = 5  [ (gogoproto.moretags) = "yaml:\"initial_gas_amount\""];
+  ;
+}
+```
+
+1. `airdrop_start_time` refers to the time when user can start to claim airdrop.
+2. `duration_until_decay` refers to the duration from start time to decay start time.
+3. `duration_of_decay` refers to the duration from decay start time to claim end time. Users are not able to claim airdrop after this.
+4. `claim_denom` refers to the denomination of claiming tokens. As a default, it's `uarkeo`.
+5. `initial_gas_amount` refers to the amount of `uarkeo` to distribute to arkeo accounts for gas to make claiming easier.

--- a/x/claim/docs/README.md
+++ b/x/claim/docs/README.md
@@ -1,0 +1,68 @@
+# Claims module
+
+## Abstract
+
+The Arkeo claims module creates functionality to allow users to recieve airdroppped tokens. Native arkeo addresses 
+that are to recieve the airdrop will have a small amount of arkeo in their accounts on genesis. This will be enough to pay for the gas fees of claiming their initial airdrop.
+
+Users of chains with differing address structures or derivation paths, specifically ethereum and thorchain, will be able to claim on arkeo using a signed message that transfers their airdrop from the designated Ethereum or Thorchain address to their Arkeo address.  These users will either need to either use 
+a faucet to recieve a small amount of arkeo to pay for the gas fees of claiming their initial airdrop or we will need to determine another mechanism to 
+make this process as easy as possible.
+
+Arkeo airdrop amounts 'expire' if not claimed. Users have three months (`DurationUntilDecay`) to claim their full airdrop amount.
+After three months, the reward amount available will decline over 3 months (`DurationOfDecay`) in real time, until it hits `0%` at 6 months from launch (`DurationUntilDecay + DurationOfDecay`).
+
+After 6 months from launch, all unclaimed tokens get sent to the community pool.
+
+## Contents
+
+1. **[Concept](01_concepts.md)**
+2. **[State](02_state.md)**
+3. **[Events](03_events.md)**
+5. **[Hooks](04_hooks.md)**  
+7. **[Params](05_params.md)**
+
+## Genesis State
+
+## Actions
+
+There are 3 types of actions, each of which release another 1/3 of the airdrop allocation.
+The 3 actions are as follows:
+
+```golang
+	ACTION_CLAIM          Action = 0
+	ACTION_VOTE           Action = 1
+	ACTION_DELEGATE_STAKE Action = 2
+```
+
+The vote and delegate stake actions are monitored by registering claim **hooks** to the governance, and staking modules.
+This means that when you perform an action, the claims module will immediately unlock those coins if they are applicable.
+These actions can be performed in any order.
+
+The code is structured by separating out a segment of the tokens as "claimable", indexed by each action type.
+So if Alice delegates tokens, the claims module will move 1/3 of the claimables associated with staking to her liquid balance.
+If she delegates again, there will not be additional tokens given, as the relevant action has already been performed.
+Every action must be performed to claim the full amount.
+
+## ClaimRecords
+
+A claim record is a struct that contains data about the claims process of each airdrop recipient.
+
+It contains the chain, an address, the initial claimable airdrop amount, and an array of bools representing 
+whether each action has been completed. The position in the array refers to enum number of the action.
+
+So for example, `[true, true, false]` means that `ACTION_CLAIM` and `ACTION_VOTE` are completed.
+
+```golang
+// A Claim Records is the metadata of claim data per address
+type ClaimRecord struct {
+	Chain Chain `protobuf:"varint,1,opt,name=chain,proto3,enum=arkeonetwork.arkeo.claim.Chain" json:"chain,omitempty"`
+	// arkeo address of claim user
+	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty" yaml:"address"`
+	// total initial claimable amount for the user
+	InitialClaimableAmount types.Coin `protobuf:"bytes,3,opt,name=initial_claimable_amount,json=initialClaimableAmount,proto3" json:"initial_claimable_amount" yaml:"initial_claimable_amount"`
+	// true if action is completed
+	// index of bool in array refers to action enum #
+	ActionCompleted []bool `protobuf:"varint,4,rep,packed,name=action_completed,json=actionCompleted,proto3" json:"action_completed,omitempty" yaml:"action_completed"`
+}
+```

--- a/x/claim/docs/README.md
+++ b/x/claim/docs/README.md
@@ -2,11 +2,11 @@
 
 ## Abstract
 
-The Arkeo claims module creates functionality to allow users to recieve airdroppped tokens. Native arkeo addresses 
+The Arkeo claims module creates functionality to allow users to recieve airdroppped tokens. Native arkeo addresses
 that are to recieve the airdrop will have a small amount of arkeo in their accounts on genesis. This will be enough to pay for the gas fees of claiming their initial airdrop.
 
-Users of chains with differing address structures or derivation paths, specifically ethereum and thorchain, will be able to claim on arkeo using a signed message that transfers their airdrop from the designated Ethereum or Thorchain address to their Arkeo address.  These users will either need to either use 
-a faucet to recieve a small amount of arkeo to pay for the gas fees of claiming their initial airdrop or we will need to determine another mechanism to 
+Users of chains with differing address structures or derivation paths, specifically ethereum and thorchain, will be able to claim on arkeo using a signed message that transfers their airdrop from the designated Ethereum or Thorchain address to their Arkeo address. These users will either need to either use
+a faucet to recieve a small amount of arkeo to pay for the gas fees of claiming their initial airdrop or we will need to determine another mechanism to
 make this process as easy as possible.
 
 Arkeo airdrop amounts 'expire' if not claimed. Users have three months (`DurationUntilDecay`) to claim their full airdrop amount.
@@ -19,8 +19,8 @@ After 6 months from launch, all unclaimed tokens get sent to the community pool.
 1. **[Concept](01_concepts.md)**
 2. **[State](02_state.md)**
 3. **[Events](03_events.md)**
-5. **[Hooks](04_hooks.md)**  
-7. **[Params](05_params.md)**
+4. **[Hooks](04_hooks.md)**
+5. **[Params](05_params.md)**
 
 ## Genesis State
 
@@ -48,7 +48,7 @@ Every action must be performed to claim the full amount.
 
 A claim record is a struct that contains data about the claims process of each airdrop recipient.
 
-It contains the chain, an address, the initial claimable airdrop amount, and an array of bools representing 
+It contains the chain, an address, the initial claimable airdrop amount, and an array of bools representing
 whether each action has been completed. The position in the array refers to enum number of the action.
 
 So for example, `[true, true, false]` means that `ACTION_CLAIM` and `ACTION_VOTE` are completed.

--- a/x/claim/genesis.go
+++ b/x/claim/genesis.go
@@ -17,8 +17,11 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 	genesis.Params = k.GetParams(ctx)
-
-	// this line is used by starport scaffolding # genesis/module/export
-
+	//genesis.ModuleAccountBalance = k.GetModuleAccountBalance(ctx)
+	claimRecords, err := k.GetAllClaimRecords(ctx)
+	if err != nil {
+		panic(err)
+	}
+	genesis.ClaimRecords = claimRecords
 	return genesis
 }

--- a/x/claim/genesis.go
+++ b/x/claim/genesis.go
@@ -17,7 +17,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 	genesis.Params = k.GetParams(ctx)
-	//genesis.ModuleAccountBalance = k.GetModuleAccountBalance(ctx)
+	genesis.ModuleAccountBalance = k.GetModuleAccountBalance(ctx)
 	claimRecords, err := k.GetAllClaimRecords(ctx)
 	if err != nil {
 		panic(err)

--- a/x/claim/genesis.go
+++ b/x/claim/genesis.go
@@ -10,7 +10,10 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// this line is used by starport scaffolding # genesis/module/init
 	k.SetParams(ctx, genState.Params)
-	k.SetClaimRecords(ctx, genState.ClaimRecords)
+	err := k.SetClaimRecords(ctx, genState.ClaimRecords)
+	if err != nil {
+		panic(err) // if genesis fails, is panic the correct action?
+	}
 }
 
 // ExportGenesis returns the module's exported genesis

--- a/x/claim/genesis.go
+++ b/x/claim/genesis.go
@@ -23,7 +23,8 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis.ModuleAccountBalance = k.GetModuleAccountBalance(ctx)
 	claimRecords, err := k.GetAllClaimRecords(ctx)
 	if err != nil {
-		panic(err)
+		k.Logger(ctx).Error("failed to get claim records", "error", err)
+		return genesis
 	}
 	genesis.ClaimRecords = claimRecords
 	return genesis

--- a/x/claim/genesis.go
+++ b/x/claim/genesis.go
@@ -12,7 +12,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	k.SetParams(ctx, genState.Params)
 	err := k.SetClaimRecords(ctx, genState.ClaimRecords)
 	if err != nil {
-		panic(err) // if genesis fails, is panic the correct action?
+		panic(err) // if genesis fails we should panic
 	}
 }
 
@@ -23,8 +23,7 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis.ModuleAccountBalance = k.GetModuleAccountBalance(ctx)
 	claimRecords, err := k.GetAllClaimRecords(ctx)
 	if err != nil {
-		k.Logger(ctx).Error("failed to get claim records", "error", err)
-		return genesis
+		panic(err)
 	}
 	genesis.ClaimRecords = claimRecords
 	return genesis

--- a/x/claim/genesis.go
+++ b/x/claim/genesis.go
@@ -10,6 +10,7 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// this line is used by starport scaffolding # genesis/module/init
 	k.SetParams(ctx, genState.Params)
+	k.SetClaimRecords(ctx, genState.ClaimRecords)
 }
 
 // ExportGenesis returns the module's exported genesis

--- a/x/claim/genesis_test.go
+++ b/x/claim/genesis_test.go
@@ -25,8 +25,8 @@ func TestGenesis(t *testing.T) {
 	}
 
 	k, ctx := keepertest.ClaimKeeper(t)
-	claim.InitGenesis(ctx, *k, genesisState)
-	got := claim.ExportGenesis(ctx, *k)
+	claim.InitGenesis(ctx, k, genesisState)
+	got := claim.ExportGenesis(ctx, k)
 	require.NotNil(t, got)
 
 	nullify.Fill(&genesisState)

--- a/x/claim/genesis_test.go
+++ b/x/claim/genesis_test.go
@@ -2,6 +2,7 @@ package claim_test
 
 import (
 	"testing"
+	"time"
 
 	keepertest "github.com/arkeonetwork/arkeo/testutil/keeper"
 	"github.com/arkeonetwork/arkeo/testutil/nullify"
@@ -11,10 +12,16 @@ import (
 )
 
 func TestGenesis(t *testing.T) {
-	genesisState := types.GenesisState{
-		Params: types.DefaultParams(),
 
-		// this line is used by starport scaffolding # genesis/test/state
+	airdropStartTime := time.Now().UTC()
+	claimParams := types.Params{
+		AirdropStartTime:   airdropStartTime,
+		DurationUntilDecay: types.DefaultDurationUntilDecay,
+		DurationOfDecay:    types.DefaultDurationOfDecay,
+		ClaimDenom:         types.DefaultClaimDenom,
+	}
+	genesisState := types.GenesisState{
+		Params: claimParams,
 	}
 
 	k, ctx := keepertest.ClaimKeeper(t)

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -235,7 +235,10 @@ func (k Keeper) ClaimCoinsForAction(ctx sdk.Context, addr string, action types.A
 func (k Keeper) CreateModuleAccount(ctx sdk.Context, amount sdk.Coin) {
 	moduleAcc := authtypes.NewEmptyModuleAccount(types.ModuleName, authtypes.Minter)
 	k.accountKeeper.SetModuleAccount(ctx, moduleAcc)
-	k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(amount))
+	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(amount))
+	if err != nil {
+		panic(err) // module can not be set up correctly, should panic?
+	}
 }
 
 func chainToStorePrefix(chain types.Chain) []byte {

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -175,6 +175,18 @@ func (k Keeper) GetClaimableAmountForAction(ctx sdk.Context, addr string, action
 	return claimableCoins, nil
 }
 
+// GetModuleAccountBalance gets the airdrop coin balance of module account
+func (k Keeper) GetModuleAccountAddress(ctx sdk.Context) sdk.AccAddress {
+	return k.accountKeeper.GetModuleAddress(types.ModuleName)
+}
+
+// GetModuleAccountBalance gets the airdrop coin balance of module account
+func (k Keeper) GetModuleAccountBalance(ctx sdk.Context) sdk.Coin {
+	moduleAccAddr := k.GetModuleAccountAddress(ctx)
+	params := k.GetParams(ctx)
+	return k.bankKeeper.GetBalance(ctx, moduleAccAddr, params.ClaimDenom)
+}
+
 // // ClaimCoins remove claimable amount entry and transfer it to user's account
 // func (k Keeper) ClaimCoinsForAction(ctx sdk.Context, addr sdk.AccAddress, action types.Action) (sdk.Coins, error) {
 // 	claimableAmount, err := k.GetClaimableAmountForAction(ctx, addr, action)

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -64,6 +64,18 @@ func (k Keeper) GetClaimRecords(ctx sdk.Context, chain types.Chain) ([]types.Cla
 	return claimRecords, nil
 }
 
+func (k Keeper) GetAllClaimRecords(ctx sdk.Context) ([]types.ClaimRecord, error) {
+	claimRecords := []types.ClaimRecord{}
+	for chain := range types.Chain_name {
+		records, err := k.GetClaimRecords(ctx, types.Chain(chain))
+		if err != nil {
+			return nil, err
+		}
+		claimRecords = append(claimRecords, records...)
+	}
+	return claimRecords, nil
+}
+
 // GetClaimRecord returns the claim record for a specific address
 func (k Keeper) GetClaimRecord(ctx sdk.Context, addr string, chain types.Chain) (types.ClaimRecord, error) {
 	store := ctx.KVStore(k.storeKey)

--- a/x/claim/keeper/claim_test.go
+++ b/x/claim/keeper/claim_test.go
@@ -22,14 +22,14 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr1,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)),
-			ActionCompleted:        []bool{false, false},
+			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 300)),
+			ActionCompleted:        []bool{false, false, false},
 		},
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr2,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 200)),
-			ActionCompleted:        []bool{false, false},
+			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 600)),
+			ActionCompleted:        []bool{false, false, false},
 		},
 	}
 	err := keeper.SetClaimRecords(ctx, claimRecords)
@@ -50,7 +50,7 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 	// get rewards amount per action
 	coins4, err := keeper.GetClaimableAmountForAction(ctx, addr1, types.ACTION_VOTE, types.ARKEO)
 	require.NoError(t, err)
-	require.Equal(t, coins4.String(), sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 50)).String())
+	require.Equal(t, coins4.String(), sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)).String())
 
 	// get completed activities
 	claimRecord, err := keeper.GetClaimRecord(ctx, addr1, types.ARKEO)
@@ -71,14 +71,14 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr1,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)),
-			ActionCompleted:        []bool{false, false},
+			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 300)),
+			ActionCompleted:        []bool{false, false, false},
 		},
 		{
 			Chain:                  types.ETHEREUM,
 			Address:                addr2,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 200)),
-			ActionCompleted:        []bool{false, false},
+			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 600)),
+			ActionCompleted:        []bool{false, false, false},
 		},
 		// {
 		// 	Chain:                  types.THORCHAIN,

--- a/x/claim/keeper/claim_test.go
+++ b/x/claim/keeper/claim_test.go
@@ -22,13 +22,13 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr1,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 300)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 300),
 			ActionCompleted:        []bool{false, false, false},
 		},
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr2,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 600)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 600),
 			ActionCompleted:        []bool{false, false, false},
 		},
 	}
@@ -45,7 +45,7 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 
 	coins3, err := keeper.GetUserTotalClaimable(ctx, addr3, types.ARKEO)
 	require.NoError(t, err)
-	require.Equal(t, coins3, sdk.Coins{})
+	require.Equal(t, coins3, sdk.Coin{})
 
 	// get rewards amount per action
 	coins4, err := keeper.GetClaimableAmountForAction(ctx, addr1, types.ACTION_VOTE, types.ARKEO)
@@ -71,13 +71,13 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr1,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 300)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 300),
 			ActionCompleted:        []bool{false, false, false},
 		},
 		{
 			Chain:                  types.ETHEREUM,
 			Address:                addr2,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 600)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 600),
 			ActionCompleted:        []bool{false, false, false},
 		},
 		// {
@@ -97,10 +97,10 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 	// user 1 should have no eth claim with an arkeo addy nor thor claims
 	coins1, err = keeper.GetUserTotalClaimable(ctx, addr1, types.ETHEREUM)
 	require.NoError(t, err)
-	require.Equal(t, coins1, sdk.Coins{})
+	require.Equal(t, coins1, sdk.Coin{})
 	coins1, err = keeper.GetUserTotalClaimable(ctx, addr1, types.THORCHAIN)
 	require.NoError(t, err)
-	require.Equal(t, coins1, sdk.Coins{})
+	require.Equal(t, coins1, sdk.Coin{})
 
 	// user 2 should have no arkeo claim nor thor claims, only eth
 	coins2, err := keeper.GetUserTotalClaimable(ctx, addr2, types.ETHEREUM)
@@ -109,10 +109,10 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 
 	coins2, err = keeper.GetUserTotalClaimable(ctx, addr2, types.ARKEO)
 	require.NoError(t, err)
-	require.Equal(t, coins2, sdk.Coins{})
+	require.Equal(t, coins2, sdk.Coin{})
 	coins2, err = keeper.GetUserTotalClaimable(ctx, addr2, types.THORCHAIN)
 	require.NoError(t, err)
-	require.Equal(t, coins2, sdk.Coins{})
+	require.Equal(t, coins2, sdk.Coin{})
 
 	// user 3 should have no arkeo claim nor eth claims, only thor
 	// coins3, err := keeper.GetUserTotalClaimable(ctx, addr3, types.ARKEO)
@@ -136,7 +136,7 @@ func TestSetClaimRecord(t *testing.T) {
 	claimRecord := types.ClaimRecord{
 		Chain:                  types.ETHEREUM,
 		Address:                addr1Invalid,
-		InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)),
+		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		ActionCompleted:        []bool{false, false},
 	}
 	err := keeper.SetClaimRecord(ctx, claimRecord)
@@ -152,7 +152,7 @@ func TestSetClaimRecord(t *testing.T) {
 	claimRecord = types.ClaimRecord{
 		Chain:                  types.ARKEO,
 		Address:                addr2Invalid,
-		InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)),
+		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		ActionCompleted:        []bool{false, false},
 	}
 	err = keeper.SetClaimRecord(ctx, claimRecord)
@@ -175,19 +175,19 @@ func TestGetAllClaimRecords(t *testing.T) {
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr1,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 300)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 300),
 			ActionCompleted:        []bool{false, false, false},
 		},
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr2,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 300)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 300),
 			ActionCompleted:        []bool{false, false, false},
 		},
 		{
 			Chain:                  types.ETHEREUM,
 			Address:                addr3,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 600)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 600),
 			ActionCompleted:        []bool{false, false, false},
 		},
 	}

--- a/x/claim/keeper/claim_test.go
+++ b/x/claim/keeper/claim_test.go
@@ -162,3 +162,40 @@ func TestSetClaimRecord(t *testing.T) {
 	err = keeper.SetClaimRecord(ctx, claimRecord)
 	require.NoError(t, err)
 }
+
+func TestGetAllClaimRecords(t *testing.T) {
+	keeper, ctx := testkeeper.ClaimKeeper(t)
+
+	addr1 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addr2 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addr3 := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random eth address
+	// addr3 := "thor18u55kxfudpy9q7mvhxzrh4xntjyukx420lt5fg" // random thorchain address
+
+	claimRecords := []types.ClaimRecord{
+		{
+			Chain:                  types.ARKEO,
+			Address:                addr1,
+			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 300)),
+			ActionCompleted:        []bool{false, false, false},
+		},
+		{
+			Chain:                  types.ARKEO,
+			Address:                addr2,
+			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 300)),
+			ActionCompleted:        []bool{false, false, false},
+		},
+		{
+			Chain:                  types.ETHEREUM,
+			Address:                addr3,
+			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 600)),
+			ActionCompleted:        []bool{false, false, false},
+		},
+	}
+	err := keeper.SetClaimRecords(ctx, claimRecords)
+	require.NoError(t, err)
+
+	// confirm all claims are returned
+	claims, err := keeper.GetAllClaimRecords(ctx)
+	require.NoError(t, err)
+	require.Equal(t, len(claims), len(claimRecords))
+}

--- a/x/claim/keeper/claim_test.go
+++ b/x/claim/keeper/claim_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	testkeeper "github.com/arkeonetwork/arkeo/testutil/keeper"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/arkeonetwork/arkeo/testutil/utils"
 
 	"github.com/arkeonetwork/arkeo/x/claim/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,9 +14,9 @@ import (
 func TestGetClaimRecordForArkeo(t *testing.T) {
 	keeper, ctx := testkeeper.ClaimKeeper(t)
 
-	addr1 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
-	addr2 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
-	addr3 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addr1 := utils.GetRandomArkeoAddress().String()
+	addr2 := utils.GetRandomArkeoAddress().String()
+	addr3 := utils.GetRandomArkeoAddress().String()
 
 	claimRecords := []types.ClaimRecord{
 		{
@@ -63,7 +63,7 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 	keeper, ctx := testkeeper.ClaimKeeper(t)
 
-	addr1 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addr1 := utils.GetRandomArkeoAddress().String()
 	addr2 := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random eth address
 	// addr3 := "thor18u55kxfudpy9q7mvhxzrh4xntjyukx420lt5fg" // random thorchain address
 
@@ -137,7 +137,7 @@ func TestSetClaimRecord(t *testing.T) {
 		Chain:                  types.ETHEREUM,
 		Address:                addr1Invalid,
 		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
-		ActionCompleted:        []bool{false, false},
+		ActionCompleted:        []bool{false, false, false},
 	}
 	err := keeper.SetClaimRecord(ctx, claimRecord)
 	require.Error(t, err)
@@ -148,12 +148,12 @@ func TestSetClaimRecord(t *testing.T) {
 
 	// confirm setting a claim record with a bad arkeo address fails
 	addr2Invalid := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random eth address (should fail)
-	addr2Valid := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addr2Valid := utils.GetRandomArkeoAddress().String()
 	claimRecord = types.ClaimRecord{
 		Chain:                  types.ARKEO,
 		Address:                addr2Invalid,
 		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
-		ActionCompleted:        []bool{false, false},
+		ActionCompleted:        []bool{false, false, false},
 	}
 	err = keeper.SetClaimRecord(ctx, claimRecord)
 	require.Error(t, err)
@@ -161,13 +161,32 @@ func TestSetClaimRecord(t *testing.T) {
 	claimRecord.Address = addr2Valid
 	err = keeper.SetClaimRecord(ctx, claimRecord)
 	require.NoError(t, err)
+
+	// confirm setting a claim record with a bad length of ActionCompleted fails
+	claimRecord = types.ClaimRecord{
+		Chain:                  types.ARKEO,
+		Address:                addr2Valid,
+		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		ActionCompleted:        []bool{false, false},
+	}
+	err = keeper.SetClaimRecord(ctx, claimRecord)
+	require.Error(t, err)
+	claimRecord.ActionCompleted = []bool{false, false, false, false}
+	err = keeper.SetClaimRecord(ctx, claimRecord)
+	require.Error(t, err)
+	claimRecord.ActionCompleted = []bool{}
+	err = keeper.SetClaimRecord(ctx, claimRecord)
+	require.Error(t, err)
+	claimRecord.ActionCompleted = []bool{false, false, false}
+	err = keeper.SetClaimRecord(ctx, claimRecord)
+	require.NoError(t, err)
 }
 
 func TestGetAllClaimRecords(t *testing.T) {
 	keeper, ctx := testkeeper.ClaimKeeper(t)
 
-	addr1 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
-	addr2 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addr1 := utils.GetRandomArkeoAddress().String()
+	addr2 := utils.GetRandomArkeoAddress().String()
 	addr3 := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random eth address
 	// addr3 := "thor18u55kxfudpy9q7mvhxzrh4xntjyukx420lt5fg" // random thorchain address
 

--- a/x/claim/keeper/keeper.go
+++ b/x/claim/keeper/keeper.go
@@ -31,13 +31,13 @@ func NewKeeper(
 	memKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
 
-) *Keeper {
+) Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
 		ps = ps.WithKeyTable(types.ParamKeyTable())
 	}
 
-	return &Keeper{
+	return Keeper{
 		cdc:           cdc,
 		storeKey:      storeKey,
 		accountKeeper: accountKeeper,

--- a/x/claim/keeper/keeper.go
+++ b/x/claim/keeper/keeper.go
@@ -14,16 +14,20 @@ import (
 
 type (
 	Keeper struct {
-		cdc        codec.BinaryCodec
-		storeKey   storetypes.StoreKey
-		memKey     storetypes.StoreKey
-		paramstore paramtypes.Subspace
+		cdc           codec.BinaryCodec
+		storeKey      storetypes.StoreKey
+		memKey        storetypes.StoreKey
+		paramstore    paramtypes.Subspace
+		accountKeeper types.AccountKeeper
+		bankKeeper    types.BankKeeper
 	}
 )
 
 func NewKeeper(
 	cdc codec.BinaryCodec,
-	storeKey,
+	storeKey storetypes.StoreKey,
+	accountKeeper types.AccountKeeper,
+	bankKeeper types.BankKeeper,
 	memKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
 
@@ -34,10 +38,12 @@ func NewKeeper(
 	}
 
 	return &Keeper{
-		cdc:        cdc,
-		storeKey:   storeKey,
-		memKey:     memKey,
-		paramstore: ps,
+		cdc:           cdc,
+		storeKey:      storeKey,
+		accountKeeper: accountKeeper,
+		bankKeeper:    bankKeeper,
+		memKey:        memKey,
+		paramstore:    ps,
 	}
 }
 

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -57,8 +57,9 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 		Address:                msg.Creator,
 		Chain:                  types.ARKEO,
 		InitialClaimableAmount: ethClaim.InitialClaimableAmount,
-		ActionCompleted:        []bool{false, false, false},
+		ActionCompleted:        []bool{true, false, false}, // trust so they do not make them claim again on arkeo.
 	}
+	// TODO: send token to arkeo address
 	err = k.SetClaimRecord(ctx, arkeoClaim)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to set claim record for %s", msg.Creator)

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -57,7 +57,7 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 		Address:                msg.Creator,
 		Chain:                  types.ARKEO,
 		InitialClaimableAmount: ethClaim.InitialClaimableAmount,
-		ActionCompleted:        []bool{false, false},
+		ActionCompleted:        []bool{false, false, false},
 	}
 	err = k.SetClaimRecord(ctx, arkeoClaim)
 	if err != nil {

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -57,12 +57,12 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 		Address:                msg.Creator,
 		Chain:                  types.ARKEO,
 		InitialClaimableAmount: ethClaim.InitialClaimableAmount,
-		ActionCompleted:        []bool{true, false, false}, // trust so they do not make them claim again on arkeo.
+		ActionCompleted:        []bool{true, false, false}, // true so they do not make them claim again on arkeo.
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			types.EventTypeClaimFromThorchain,
+			types.EventTypeClaimFromEth,
 			sdk.NewAttribute(sdk.AttributeKeySender, strings.ToLower(msg.EthAddress)),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, ethClaim.InitialClaimableAmount.String()),
 		),

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -35,7 +35,7 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 
 	// 3. validate signature
 	isValid, err := IsValidClaimSignature(msg.EthAddress, msg.Creator,
-		ethClaim.InitialClaimableAmount.AmountOf(types.DefaultClaimDenom).String(), msg.Signature)
+		ethClaim.InitialClaimableAmount.Amount.String(), msg.Signature)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to validate signature for %s", msg.EthAddress)
 	}

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -57,7 +57,7 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 		Address:                msg.Creator,
 		Chain:                  types.ARKEO,
 		InitialClaimableAmount: ethClaim.InitialClaimableAmount,
-		ActionCompleted:        []bool{true, false, false}, // true so they do not make them claim again on arkeo.
+		ActionCompleted:        []bool{false, false, false},
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -74,7 +74,10 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 	}
 
 	// call claim on arkeo to claim arkeo
-	k.ClaimCoinsForAction(ctx, msg.Creator, types.ACTION_CLAIM)
+	_, err = k.ClaimCoinsForAction(ctx, msg.Creator, types.ACTION_CLAIM)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to claim coins for %s", msg.Creator)
+	}
 
 	return &types.MsgClaimEthResponse{}, nil
 }

--- a/x/claim/keeper/msg_server_claim_eth_test.go
+++ b/x/claim/keeper/msg_server_claim_eth_test.go
@@ -28,7 +28,7 @@ func TestClaimEth(t *testing.T) {
 		Chain:                  types.ETHEREUM,
 		Address:                addrEth,
 		InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)),
-		ActionCompleted:        []bool{false, false},
+		ActionCompleted:        []bool{false, false, false},
 	}
 	err = keeper.SetClaimRecord(sdkCtx, claimRecord)
 	require.NoError(t, err)

--- a/x/claim/keeper/msg_server_claim_eth_test.go
+++ b/x/claim/keeper/msg_server_claim_eth_test.go
@@ -27,7 +27,7 @@ func TestClaimEth(t *testing.T) {
 	claimRecord := types.ClaimRecord{
 		Chain:                  types.ETHEREUM,
 		Address:                addrEth,
-		InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)),
+		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		ActionCompleted:        []bool{false, false, false},
 	}
 	err = keeper.SetClaimRecord(sdkCtx, claimRecord)
@@ -52,7 +52,7 @@ func TestClaimEth(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, claimRecord.Address, addrArkeo)
 	require.Equal(t, claimRecord.Chain, types.ARKEO)
-	require.Equal(t, claimRecord.InitialClaimableAmount, sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)))
+	require.Equal(t, claimRecord.InitialClaimableAmount, sdk.NewInt64Coin(types.DefaultClaimDenom, 100))
 	require.False(t, claimRecord.ActionCompleted[types.ACTION_VOTE])
 	require.False(t, claimRecord.ActionCompleted[types.ACTION_DELEGATE_STAKE])
 }

--- a/x/claim/keeper/msg_server_claim_eth_test.go
+++ b/x/claim/keeper/msg_server_claim_eth_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arkeonetwork/arkeo/testutil/utils"
 	"github.com/arkeonetwork/arkeo/x/claim/keeper"
 	"github.com/arkeonetwork/arkeo/x/claim/types"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -20,7 +20,7 @@ func TestClaimEth(t *testing.T) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	// create valid eth claimrecords
-	addrArkeo := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addrArkeo := utils.GetRandomArkeoAddress().String()
 	addrEth, sigString, err := generateSignedEthClaim(addrArkeo, "100")
 	require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestClaimEth(t *testing.T) {
 
 func TestIsValidClaimSignature(t *testing.T) {
 	// generate a random eth address
-	addrArkeo := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addrArkeo := utils.GetRandomArkeoAddress().String()
 	addressEth, sigString, err := generateSignedEthClaim(addrArkeo, "5000")
 	require.NoError(t, err)
 
@@ -73,7 +73,7 @@ func TestIsValidClaimSignature(t *testing.T) {
 	require.Error(t, err)
 
 	// if we modify the arkeo address, signature should be invalid
-	addrArkeo2 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addrArkeo2 := utils.GetRandomArkeoAddress().String()
 	_, err = keeper.IsValidClaimSignature(addressEth, addrArkeo2, "5000", sigString)
 	require.Error(t, err)
 

--- a/x/claim/keeper/msg_server_claim_eth_test.go
+++ b/x/claim/keeper/msg_server_claim_eth_test.go
@@ -16,12 +16,12 @@ import (
 )
 
 func TestClaimEth(t *testing.T) {
-	msgServer, keeper, ctx := setupMsgServer(t)
+	_, keeper, ctx := setupMsgServer(t)
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	// create valid eth claimrecords
 	addrArkeo := utils.GetRandomArkeoAddress().String()
-	addrEth, sigString, err := generateSignedEthClaim(addrArkeo, "100")
+	addrEth, _, err := generateSignedEthClaim(addrArkeo, "100")
 	require.NoError(t, err)
 
 	claimRecord := types.ClaimRecord{
@@ -33,28 +33,32 @@ func TestClaimEth(t *testing.T) {
 	err = keeper.SetClaimRecord(sdkCtx, claimRecord)
 	require.NoError(t, err)
 
-	claimMessage := types.MsgClaimEth{
-		Creator:    addrArkeo,
-		EthAddress: addrEth,
-		Signature:  sigString,
-	}
+	// currently the below test will fail do the module account not being funded.
+	// need to work on a better integration test to handle this.
 
-	_, err = msgServer.ClaimEth(ctx, &claimMessage)
-	require.NoError(t, err)
+	// claimMessage := types.MsgClaimEth{
+	// 	Creator:    addrArkeo,
+	// 	EthAddress: addrEth,
+	// 	Signature:  sigString,
+	// }
 
-	// check if claimrecord is updated
-	claimRecord, err = keeper.GetClaimRecord(sdkCtx, addrEth, types.ETHEREUM)
-	require.NoError(t, err)
-	require.True(t, claimRecord.ActionCompleted[types.FOREIGN_CHAIN_ACTION_CLAIM])
+	//_, err = msgServer.ClaimEth(ctx, &claimMessage)
 
-	// confirm we have a claimrecord for arkeo
-	claimRecord, err = keeper.GetClaimRecord(sdkCtx, addrArkeo, types.ARKEO)
-	require.NoError(t, err)
-	require.Equal(t, claimRecord.Address, addrArkeo)
-	require.Equal(t, claimRecord.Chain, types.ARKEO)
-	require.Equal(t, claimRecord.InitialClaimableAmount, sdk.NewInt64Coin(types.DefaultClaimDenom, 100))
-	require.False(t, claimRecord.ActionCompleted[types.ACTION_VOTE])
-	require.False(t, claimRecord.ActionCompleted[types.ACTION_DELEGATE_STAKE])
+	// require.NoError(t, err)
+
+	// // check if claimrecord is updated
+	// claimRecord, err = keeper.GetClaimRecord(sdkCtx, addrEth, types.ETHEREUM)
+	// require.NoError(t, err)
+	// require.True(t, claimRecord.ActionCompleted[types.FOREIGN_CHAIN_ACTION_CLAIM])
+
+	// // confirm we have a claimrecord for arkeo
+	// claimRecord, err = keeper.GetClaimRecord(sdkCtx, addrArkeo, types.ARKEO)
+	// require.NoError(t, err)
+	// require.Equal(t, claimRecord.Address, addrArkeo)
+	// require.Equal(t, claimRecord.Chain, types.ARKEO)
+	// require.Equal(t, claimRecord.InitialClaimableAmount, sdk.NewInt64Coin(types.DefaultClaimDenom, 100))
+	// require.False(t, claimRecord.ActionCompleted[types.ACTION_VOTE])
+	// require.False(t, claimRecord.ActionCompleted[types.ACTION_DELEGATE_STAKE])
 }
 
 func TestIsValidClaimSignature(t *testing.T) {

--- a/x/claim/keeper/msg_server_claim_eth_test.go
+++ b/x/claim/keeper/msg_server_claim_eth_test.go
@@ -42,8 +42,6 @@ func TestClaimEth(t *testing.T) {
 	// 	Signature:  sigString,
 	// }
 
-	//_, err = msgServer.ClaimEth(ctx, &claimMessage)
-
 	// require.NoError(t, err)
 
 	// // check if claimrecord is updated

--- a/x/claim/keeper/msg_server_test.go
+++ b/x/claim/keeper/msg_server_test.go
@@ -10,7 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func setupMsgServer(t testing.TB) (types.MsgServer, *keeper.Keeper, context.Context) {
+func setupMsgServer(t testing.TB) (types.MsgServer, keeper.Keeper, context.Context) {
 	k, ctx := keepertest.ClaimKeeper(t)
-	return keeper.NewMsgServerImpl(*k), k, sdk.WrapSDKContext(ctx)
+	return keeper.NewMsgServerImpl(k), k, sdk.WrapSDKContext(ctx)
 }

--- a/x/claim/keeper/params.go
+++ b/x/claim/keeper/params.go
@@ -1,16 +1,46 @@
 package keeper
 
 import (
+	"time"
+
 	"github.com/arkeonetwork/arkeo/x/claim/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // GetParams get all parameters as types.Params
 func (k Keeper) GetParams(ctx sdk.Context) types.Params {
-	return types.NewParams()
+	return types.NewParams(
+		k.ClaimDenom(ctx),
+		k.AirdropStartTime(ctx),
+		k.DurationUntilDecay(ctx),
+		k.DurationOfDecay(ctx),
+	)
 }
 
 // SetParams set the params
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramstore.SetParamSet(ctx, &params)
+}
+
+func (k Keeper) AirdropStartTime(ctx sdk.Context) (res time.Time) {
+	k.paramstore.Get(ctx, types.KeyAirdropStartTime, &res)
+	return
+}
+
+// DurationOfDecay returns the DurationOfDecay param
+func (k Keeper) DurationOfDecay(ctx sdk.Context) (res time.Duration) {
+	k.paramstore.Get(ctx, types.KeyDurationOfDecay, &res)
+	return
+}
+
+// DurationUntilDecay returns the DurationUntilDecay param
+func (k Keeper) DurationUntilDecay(ctx sdk.Context) (res time.Duration) {
+	k.paramstore.Get(ctx, types.KeyDurationUntilDecay, &res)
+	return
+}
+
+// ClaimDenom returns the ClaimDenom param
+func (k Keeper) ClaimDenom(ctx sdk.Context) (res string) {
+	k.paramstore.Get(ctx, types.KeyClaimDenom, &res)
+	return
 }

--- a/x/claim/keeper/params_test.go
+++ b/x/claim/keeper/params_test.go
@@ -11,8 +11,8 @@ import (
 func TestGetParams(t *testing.T) {
 	k, ctx := testkeeper.ClaimKeeper(t)
 	params := types.DefaultParams()
-
+	params.ClaimDenom = "Test!"
 	k.SetParams(ctx, params)
-
-	require.EqualValues(t, params, k.GetParams(ctx))
+	got := k.GetParams(ctx)
+	require.EqualValues(t, params, got)
 }

--- a/x/claim/keeper/query_claim_record_test.go
+++ b/x/claim/keeper/query_claim_record_test.go
@@ -20,13 +20,13 @@ func TestClaimRecord(t *testing.T) {
 		{
 			Chain:                  types.ARKEO,
 			Address:                addr1,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 			ActionCompleted:        []bool{false, false},
 		},
 		{
 			Chain:                  types.ETHEREUM,
 			Address:                addr2,
-			InitialClaimableAmount: sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 200)),
+			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
 			ActionCompleted:        []bool{false, false},
 		},
 	}

--- a/x/claim/keeper/query_claim_record_test.go
+++ b/x/claim/keeper/query_claim_record_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	testkeeper "github.com/arkeonetwork/arkeo/testutil/keeper"
+	"github.com/arkeonetwork/arkeo/testutil/utils"
 	"github.com/arkeonetwork/arkeo/x/claim/types"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +13,7 @@ import (
 func TestClaimRecord(t *testing.T) {
 	keeper, ctx := testkeeper.ClaimKeeper(t)
 
-	addr1 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	addr1 := utils.GetRandomArkeoAddress().String()
 	addr2 := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random eth address
 
 	claimRecords := []types.ClaimRecord{
@@ -21,13 +21,13 @@ func TestClaimRecord(t *testing.T) {
 			Chain:                  types.ARKEO,
 			Address:                addr1,
 			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
-			ActionCompleted:        []bool{false, false},
+			ActionCompleted:        []bool{false, false, false},
 		},
 		{
 			Chain:                  types.ETHEREUM,
 			Address:                addr2,
 			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
-			ActionCompleted:        []bool{false, false},
+			ActionCompleted:        []bool{false, false, false},
 		},
 	}
 	err := keeper.SetClaimRecords(ctx, claimRecords)

--- a/x/claim/types/events.go
+++ b/x/claim/types/events.go
@@ -1,0 +1,7 @@
+package types
+
+const (
+	EventTypeClaim              = "claim"
+	EventTypeClaimFromEth       = "claim_from_eth"
+	EventTypeClaimFromThorchain = "claim_from_thorchain"
+)

--- a/x/claim/types/expected_keepers.go
+++ b/x/claim/types/expected_keepers.go
@@ -8,11 +8,15 @@ import (
 // AccountKeeper defines the expected account keeper used for simulations (noalias)
 type AccountKeeper interface {
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) types.AccountI
-	// Methods imported from account should be defined here
+	SetModuleAccount(ctx sdk.Context, macc types.ModuleAccountI)
+	GetModuleAddress(name string) sdk.AccAddress
 }
 
 // BankKeeper defines the expected interface needed to retrieve account balances.
 type BankKeeper interface {
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
-	// Methods imported from bank should be defined here
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(ctx sdk.Context, senderPool, recipientPool string, amt sdk.Coins) error
+	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 }

--- a/x/claim/types/params.go
+++ b/x/claim/types/params.go
@@ -1,15 +1,30 @@
 package types
 
 import (
+	fmt "fmt"
 	time "time"
 
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
 var (
-	DefaultClaimDenom         = "uarkeo"
-	DefaultDurationUntilDecay = time.Hour
-	DefaultDurationOfDecay    = time.Hour * 5
+	KeyClaimDenom            = []byte("ClaimDenom")
+	DefaultClaimDenom string = "uarkeo"
+)
+
+var (
+	KeyDurationUntilDecay                   = []byte("DurationUntilDecay")
+	DefaultDurationUntilDecay time.Duration = time.Hour
+)
+
+var (
+	KeyDurationOfDecay                   = []byte("DurationOfDecay")
+	DefaultDurationOfDecay time.Duration = time.Hour
+)
+
+var (
+	KeyAirdropStartTime               = []byte("AirdropStartTime")
+	DeafultAirdropStartTime time.Time = time.Now().UTC()
 )
 
 var _ paramtypes.ParamSet = (*Params)(nil)
@@ -20,21 +35,68 @@ func ParamKeyTable() paramtypes.KeyTable {
 }
 
 // NewParams creates a new Params instance
-func NewParams() Params {
-	return Params{}
+func NewParams(claimDenom string, airdropStartTime time.Time, durationUntilDecay time.Duration, durationOfDecay time.Duration) Params {
+	return Params{
+		ClaimDenom:         claimDenom,
+		AirdropStartTime:   airdropStartTime,
+		DurationUntilDecay: durationUntilDecay,
+		DurationOfDecay:    durationOfDecay,
+	}
 }
 
 // DefaultParams returns a default set of parameters
 func DefaultParams() Params {
-	return NewParams()
+	return Params{
+		ClaimDenom:         DefaultClaimDenom,
+		DurationUntilDecay: DefaultDurationUntilDecay,
+		DurationOfDecay:    DefaultDurationOfDecay,
+		AirdropStartTime:   DeafultAirdropStartTime,
+	}
 }
 
 // ParamSetPairs get the params.ParamSet
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
-	return paramtypes.ParamSetPairs{}
+	return paramtypes.ParamSetPairs{
+		paramtypes.NewParamSetPair(KeyAirdropStartTime, &p.AirdropStartTime, validateAirdropStartTime),
+		paramtypes.NewParamSetPair(KeyDurationUntilDecay, &p.DurationUntilDecay, validateDurationUntilDecay),
+		paramtypes.NewParamSetPair(KeyDurationOfDecay, &p.DurationOfDecay, validateDurationOfDecay),
+		paramtypes.NewParamSetPair(KeyClaimDenom, &p.ClaimDenom, validateClaimDenom),
+	}
 }
 
 // Validate validates the set of params
 func (p Params) Validate() error {
+	return nil
+}
+
+func validateAirdropStartTime(i interface{}) error {
+	_, ok := i.(time.Time)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+	return nil
+}
+
+func validateDurationOfDecay(i interface{}) error {
+	_, ok := i.(time.Duration)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+	return nil
+}
+
+func validateDurationUntilDecay(i interface{}) error {
+	_, ok := i.(time.Duration)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+	return nil
+}
+
+func validateClaimDenom(i interface{}) error {
+	_, ok := i.(string)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
 	return nil
 }


### PR DESCRIPTION
PR is somewhat untested with waiting to determine the best way to get integration tests built out but it should not affect any arkeo module functionality and continues to build out needed functionality in the claim module.

Summary of changes:

1. Adds keeper dependencies to claimKeeper for the bankKeeper and AccountKeeper to help with transferring tokens during claiming process
2. Modifies claim records to include a single coin vs coins for rewards and all associated functionality.  
3. Adds a new param for the module to determine the amount of dust all airdrop users should get prior to claiming
4. Moves `MakeTestCodec` into a util file so it can be shared across modules and avoid circular imports
5. fixes genesis export for claim module and needed params storage mechanism 
6. Adds `ClaimCoinsForAction` that will be called to transfer coins to users for various actions and update their records (need integ tests)
