### PR TITLE
Feat/accounting improvements

### DIFF
--- a/proto/arkeo/claim/claim_record.proto
+++ b/proto/arkeo/claim/claim_record.proto
@@ -12,14 +12,7 @@ enum Action {
 
   ACTION_CLAIM = 0;
   ACTION_VOTE = 1;
-  ACTION_DELEGATE_STAKE = 2;
-}
-
-// actions for chains other than arkeo, limited currently to claiming
-enum ForeignChainAction {
-  option (gogoproto.goproto_enum_prefix) = false;
-
-  FOREIGN_CHAIN_ACTION_CLAIM = 0;
+  ACTION_DELEGATE = 2;
 }
 
 enum Chain {

--- a/proto/arkeo/claim/claim_record.proto
+++ b/proto/arkeo/claim/claim_record.proto
@@ -39,13 +39,8 @@ message ClaimRecord {
   // arkeo address of claim user
   string address = 2 [ (gogoproto.moretags) = "yaml:\"address\"" ];
 
-  // total initial claimable amount for the user
-  cosmos.base.v1beta1.Coin initial_claimable_amount = 3 [
-    (gogoproto.nullable) = false,
-    (gogoproto.moretags) = "yaml:\"initial_claimable_amount\""
-  ];
-
-  // true if action is completed
-  // index of bool in array refers to action enum #
-  repeated bool action_completed = 4 [ (gogoproto.moretags) = "yaml:\"action_completed\"" ];
+  // claimable amount per action (claim, vote, delegate - changed to 0 after action completed)
+  cosmos.base.v1beta1.Coin amount_claim = 3 [(gogoproto.nullable) = false,  (gogoproto.moretags) = "yaml:\"amount_claim\""];
+  cosmos.base.v1beta1.Coin amount_vote = 4 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"amount_vote\""];
+  cosmos.base.v1beta1.Coin amount_delegate = 5 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"amount_delegate\""];
 }

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -283,3 +283,10 @@ func setClaimableAmountForAction(claim types.ClaimRecord, action types.Action, a
 	}
 	return claim
 }
+
+func setClaimableAmountForAllActions(claim types.ClaimRecord, amount sdk.Coin) types.ClaimRecord {
+	claim.AmountClaim = amount
+	claim.AmountDelegate = amount
+	claim.AmountVote = amount
+	return claim
+}

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -193,6 +193,7 @@ func (k Keeper) ClaimCoinsForAction(ctx sdk.Context, addr string, action types.A
 	if err != nil {
 		return sdk.Coin{}, err
 	}
+
 	accountAddress, err := sdk.AccAddressFromBech32(addr)
 	if err != nil {
 		return sdk.Coin{}, err

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -102,7 +102,7 @@ func (k Keeper) GetUserTotalClaimable(ctx sdk.Context, addr string, chain types.
 	if err != nil {
 		return sdk.Coin{}, err
 	}
-	if claimRecord.Address == "" {
+	if claimRecord.IsEmpty() {
 		return sdk.Coin{}, nil
 	}
 
@@ -127,9 +127,10 @@ func (k Keeper) GetClaimableAmountForAction(ctx sdk.Context, addr string, action
 		return sdk.Coin{}, err
 	}
 
-	if claimRecord.Address == "" {
+	if claimRecord.IsEmpty() {
 		return sdk.Coin{}, nil
 	}
+
 	params := k.GetParams(ctx)
 
 	// If we are before the start time, do nothing.
@@ -185,7 +186,7 @@ func (k Keeper) ClaimCoinsForAction(ctx sdk.Context, addr string, action types.A
 		return claimableAmount, err
 	}
 
-	if claimableAmount.IsNil() {
+	if claimableAmount.IsNil() || claimableAmount.IsZero() {
 		return claimableAmount, nil
 	}
 

--- a/x/claim/keeper/claim_test.go
+++ b/x/claim/keeper/claim_test.go
@@ -49,6 +49,10 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, coins3, sdk.Coin{})
 
+	claimRecord, err := keeper.GetClaimRecord(ctx, addr3, types.ARKEO)
+	require.NoError(t, err)
+	require.Equal(t, claimRecord, types.ClaimRecord{})
+
 	// get rewards amount per action
 	coins4, err := keeper.GetClaimableAmountForAction(ctx, addr1, types.ACTION_VOTE, types.ARKEO)
 	require.NoError(t, err)

--- a/x/claim/keeper/claim_test.go
+++ b/x/claim/keeper/claim_test.go
@@ -20,16 +20,18 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 
 	claimRecords := []types.ClaimRecord{
 		{
-			Chain:                  types.ARKEO,
-			Address:                addr1,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 300),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ARKEO,
+			Address:        addr1,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		},
 		{
-			Chain:                  types.ARKEO,
-			Address:                addr2,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 600),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ARKEO,
+			Address:        addr2,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
 		},
 	}
 	err := keeper.SetClaimRecords(ctx, claimRecords)
@@ -37,11 +39,11 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 
 	coins1, err := keeper.GetUserTotalClaimable(ctx, addr1, types.ARKEO)
 	require.NoError(t, err)
-	require.Equal(t, coins1, claimRecords[0].InitialClaimableAmount, coins1.String())
+	require.Equal(t, "300", coins1.Amount.String())
 
 	coins2, err := keeper.GetUserTotalClaimable(ctx, addr2, types.ARKEO)
 	require.NoError(t, err)
-	require.Equal(t, coins2, claimRecords[1].InitialClaimableAmount)
+	require.Equal(t, "600", coins2.Amount.String())
 
 	coins3, err := keeper.GetUserTotalClaimable(ctx, addr3, types.ARKEO)
 	require.NoError(t, err)
@@ -52,12 +54,6 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, coins4.String(), sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)).String())
 
-	// get completed activities
-	claimRecord, err := keeper.GetClaimRecord(ctx, addr1, types.ARKEO)
-	require.NoError(t, err)
-	for i := range types.Action_name {
-		require.False(t, claimRecord.ActionCompleted[i])
-	}
 }
 
 func TestGetClaimRecordForMutlipleChains(t *testing.T) {
@@ -69,16 +65,18 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 
 	claimRecords := []types.ClaimRecord{
 		{
-			Chain:                  types.ARKEO,
-			Address:                addr1,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 300),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ARKEO,
+			Address:        addr1,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		},
 		{
-			Chain:                  types.ETHEREUM,
-			Address:                addr2,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 600),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ETHEREUM,
+			Address:        addr2,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
 		},
 		// {
 		// 	Chain:                  types.THORCHAIN,
@@ -92,7 +90,7 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 
 	coins1, err := keeper.GetUserTotalClaimable(ctx, addr1, types.ARKEO)
 	require.NoError(t, err)
-	require.Equal(t, coins1, claimRecords[0].InitialClaimableAmount, coins1.String())
+	require.Equal(t, "300", coins1.Amount.String())
 
 	// user 1 should have no eth claim with an arkeo addy nor thor claims
 	coins1, err = keeper.GetUserTotalClaimable(ctx, addr1, types.ETHEREUM)
@@ -105,7 +103,7 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 	// user 2 should have no arkeo claim nor thor claims, only eth
 	coins2, err := keeper.GetUserTotalClaimable(ctx, addr2, types.ETHEREUM)
 	require.NoError(t, err)
-	require.Equal(t, coins2, claimRecords[1].InitialClaimableAmount)
+	require.Equal(t, "600", coins2.Amount.String())
 
 	coins2, err = keeper.GetUserTotalClaimable(ctx, addr2, types.ARKEO)
 	require.NoError(t, err)
@@ -134,10 +132,11 @@ func TestSetClaimRecord(t *testing.T) {
 	addr1Invalid := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98"  // random invalid eth address
 	addr1Valid := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random valid eth address
 	claimRecord := types.ClaimRecord{
-		Chain:                  types.ETHEREUM,
-		Address:                addr1Invalid,
-		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
-		ActionCompleted:        []bool{false, false, false},
+		Chain:          types.ETHEREUM,
+		Address:        addr1Invalid,
+		AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 	}
 	err := keeper.SetClaimRecord(ctx, claimRecord)
 	require.Error(t, err)
@@ -150,34 +149,16 @@ func TestSetClaimRecord(t *testing.T) {
 	addr2Invalid := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random eth address (should fail)
 	addr2Valid := utils.GetRandomArkeoAddress().String()
 	claimRecord = types.ClaimRecord{
-		Chain:                  types.ARKEO,
-		Address:                addr2Invalid,
-		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
-		ActionCompleted:        []bool{false, false, false},
+		Chain:          types.ARKEO,
+		Address:        addr2Invalid,
+		AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 	}
 	err = keeper.SetClaimRecord(ctx, claimRecord)
 	require.Error(t, err)
 
 	claimRecord.Address = addr2Valid
-	err = keeper.SetClaimRecord(ctx, claimRecord)
-	require.NoError(t, err)
-
-	// confirm setting a claim record with a bad length of ActionCompleted fails
-	claimRecord = types.ClaimRecord{
-		Chain:                  types.ARKEO,
-		Address:                addr2Valid,
-		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
-		ActionCompleted:        []bool{false, false},
-	}
-	err = keeper.SetClaimRecord(ctx, claimRecord)
-	require.Error(t, err)
-	claimRecord.ActionCompleted = []bool{false, false, false, false}
-	err = keeper.SetClaimRecord(ctx, claimRecord)
-	require.Error(t, err)
-	claimRecord.ActionCompleted = []bool{}
-	err = keeper.SetClaimRecord(ctx, claimRecord)
-	require.Error(t, err)
-	claimRecord.ActionCompleted = []bool{false, false, false}
 	err = keeper.SetClaimRecord(ctx, claimRecord)
 	require.NoError(t, err)
 }
@@ -192,22 +173,25 @@ func TestGetAllClaimRecords(t *testing.T) {
 
 	claimRecords := []types.ClaimRecord{
 		{
-			Chain:                  types.ARKEO,
-			Address:                addr1,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 300),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ARKEO,
+			Address:        addr1,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		},
 		{
-			Chain:                  types.ARKEO,
-			Address:                addr2,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 300),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ARKEO,
+			Address:        addr2,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		},
 		{
-			Chain:                  types.ETHEREUM,
-			Address:                addr3,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 600),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ETHEREUM,
+			Address:        addr3,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
 		},
 	}
 	err := keeper.SetClaimRecords(ctx, claimRecords)

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -24,7 +24,7 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 		return nil, errors.Wrapf(err, "failed to get claim record for %s", msg.EthAddress)
 	}
 
-	if ethClaim == (types.ClaimRecord{}) || ethClaim.AmountClaim.IsNil() || ethClaim.AmountClaim.IsZero() {
+	if ethClaim.IsEmpty() || ethClaim.AmountClaim.IsZero() {
 		return nil, errors.Wrapf(err, "no claimable amount for %s", msg.EthAddress)
 	}
 	totalAmountClaimable := getInitialClaimableAmountTotal(ethClaim)
@@ -173,11 +173,11 @@ func has0xPrefix(str string) bool {
 }
 
 func mergeClaimRecords(claimA types.ClaimRecord, claimB types.ClaimRecord) (types.ClaimRecord, error) {
-	if claimA == (types.ClaimRecord{}) {
+	if claimA.IsEmpty() {
 		return claimB, nil
 	}
 
-	if claimB == (types.ClaimRecord{}) {
+	if claimB.IsEmpty() {
 		return claimA, nil
 	}
 

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -18,24 +18,20 @@ import (
 
 func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*types.MsgClaimEthResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	// 1. get eth claim
+	// get eth claim
 	ethClaim, err := k.GetClaimRecord(ctx, msg.EthAddress, types.ETHEREUM)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get claim record for %s", msg.EthAddress)
 	}
 
-	if ethClaim.InitialClaimableAmount.IsZero() {
+	if ethClaim == (types.ClaimRecord{}) || ethClaim.AmountClaim.IsNil() || ethClaim.AmountClaim.IsZero() {
 		return nil, errors.Wrapf(err, "no claimable amount for %s", msg.EthAddress)
 	}
+	totalAmountClaimable := getInitialClaimableAmountTotal(ethClaim)
 
-	// 2. check if already claimed
-	if ethClaim.ActionCompleted[types.FOREIGN_CHAIN_ACTION_CLAIM] {
-		return nil, errors.Wrapf(err, "already claimed for %s", msg.EthAddress)
-	}
-
-	// 3. validate signature
+	// validate signature
 	isValid, err := IsValidClaimSignature(msg.EthAddress, msg.Creator,
-		ethClaim.InitialClaimableAmount.Amount.String(), msg.Signature)
+		totalAmountClaimable.Amount.String(), msg.Signature)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to validate signature for %s", msg.EthAddress)
 	}
@@ -45,35 +41,47 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 		return nil, errors.New("invalid signature")
 	}
 
+	// create new arkeo claim
+	arkeoClaim := types.ClaimRecord{
+		Address:        msg.Creator,
+		Chain:          types.ARKEO,
+		AmountClaim:    ethClaim.AmountClaim,
+		AmountVote:     ethClaim.AmountVote,
+		AmountDelegate: ethClaim.AmountDelegate,
+	}
+
 	// set eth claim to completed
-	ethClaim.ActionCompleted[types.FOREIGN_CHAIN_ACTION_CLAIM] = true
+	ethClaim = setClaimableAmountForAction(ethClaim, types.ACTION_CLAIM, sdk.Coin{})
 	err = k.SetClaimRecord(ctx, ethClaim)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to set claim record for %s", msg.EthAddress)
-	}
-
-	// create new arkeo claim
-	arkeoClaim := types.ClaimRecord{
-		Address:                msg.Creator,
-		Chain:                  types.ARKEO,
-		InitialClaimableAmount: ethClaim.InitialClaimableAmount,
-		ActionCompleted:        []bool{false, false, false},
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeClaimFromEth,
 			sdk.NewAttribute(sdk.AttributeKeySender, strings.ToLower(msg.EthAddress)),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, ethClaim.InitialClaimableAmount.String()),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, arkeoClaim.AmountClaim.String()),
 		),
 	})
+
+	// see if there is an existing arkeo claim!
+	existingArkeoClaim, err := k.GetClaimRecord(ctx, msg.Creator, types.ARKEO)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get arkeo claim record for %s", msg.Creator)
+	}
+
+	arkeoClaim, err = mergeClaimRecords(existingArkeoClaim, arkeoClaim)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to merge claim records for %s", msg.Creator)
+	}
 
 	err = k.SetClaimRecord(ctx, arkeoClaim)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to set claim record for %s", msg.Creator)
 	}
 
-	// call claim on arkeo to claim arkeo
+	// call claim on arkeo to claim arkeo (note: this could CLAIM for all tokens that are now merged)
 	_, err = k.ClaimCoinsForAction(ctx, msg.Creator, types.ACTION_CLAIM)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to claim coins for %s", msg.Creator)
@@ -162,4 +170,27 @@ func hexDecode(s string) ([]byte, error) {
 // Has0xPrefix validates str begins with '0x' or '0X'.
 func has0xPrefix(str string) bool {
 	return strings.HasPrefix(str, "0x") || strings.HasPrefix(str, "0X")
+}
+
+func mergeClaimRecords(claimA types.ClaimRecord, claimB types.ClaimRecord) (types.ClaimRecord, error) {
+	if claimA == (types.ClaimRecord{}) {
+		return claimB, nil
+	}
+
+	if claimB == (types.ClaimRecord{}) {
+		return claimA, nil
+	}
+
+	if claimA.Address != claimB.Address {
+		return types.ClaimRecord{}, errors.New("cannot merge claims for different addresses")
+	}
+
+	if claimA.Chain != claimB.Chain {
+		return types.ClaimRecord{}, errors.New("cannot merge claims for different chains")
+	}
+
+	claimA.AmountClaim = claimA.AmountClaim.Add(claimB.AmountClaim)
+	claimA.AmountDelegate = claimA.AmountDelegate.Add(claimB.AmountDelegate)
+	claimA.AmountVote = claimA.AmountVote.Add(claimB.AmountVote)
+	return claimA, nil
 }

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -51,7 +51,7 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 	}
 
 	// set eth claim to completed
-	ethClaim = setClaimableAmountForAction(ethClaim, types.ACTION_CLAIM, sdk.Coin{})
+	ethClaim = setClaimableAmountForAllActions(ethClaim, sdk.Coin{})
 	err = k.SetClaimRecord(ctx, ethClaim)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to set claim record for %s", msg.EthAddress)

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -65,7 +65,7 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 		),
 	})
 
-	// see if there is an existing arkeo claim!
+	// see if there is an existing arkeo claim so we can merge it
 	existingArkeoClaim, err := k.GetClaimRecord(ctx, msg.Creator, types.ARKEO)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get arkeo claim record for %s", msg.Creator)

--- a/x/claim/keeper/msg_server_claim_eth_test.go
+++ b/x/claim/keeper/msg_server_claim_eth_test.go
@@ -21,14 +21,15 @@ func TestClaimEth(t *testing.T) {
 
 	// create valid eth claimrecords
 	addrArkeo := utils.GetRandomArkeoAddress().String()
-	addrEth, _, err := generateSignedEthClaim(addrArkeo, "100")
+	addrEth, _, err := generateSignedEthClaim(addrArkeo, "300")
 	require.NoError(t, err)
 
 	claimRecord := types.ClaimRecord{
-		Chain:                  types.ETHEREUM,
-		Address:                addrEth,
-		InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
-		ActionCompleted:        []bool{false, false, false},
+		Chain:          types.ETHEREUM,
+		Address:        addrEth,
+		AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 	}
 	err = keeper.SetClaimRecord(sdkCtx, claimRecord)
 	require.NoError(t, err)

--- a/x/claim/keeper/query_claim_record_test.go
+++ b/x/claim/keeper/query_claim_record_test.go
@@ -18,16 +18,18 @@ func TestClaimRecord(t *testing.T) {
 
 	claimRecords := []types.ClaimRecord{
 		{
-			Chain:                  types.ARKEO,
-			Address:                addr1,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ARKEO,
+			Address:        addr1,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		},
 		{
-			Chain:                  types.ETHEREUM,
-			Address:                addr2,
-			InitialClaimableAmount: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
-			ActionCompleted:        []bool{false, false, false},
+			Chain:          types.ETHEREUM,
+			Address:        addr2,
+			AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
+			AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
+			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
 		},
 	}
 	err := keeper.SetClaimRecords(ctx, claimRecords)

--- a/x/claim/types/claim_record.go
+++ b/x/claim/types/claim_record.go
@@ -1,0 +1,25 @@
+package types
+
+func (claimRecord *ClaimRecord) IsEmpty() bool {
+	if *claimRecord == (ClaimRecord{}) {
+		return true
+	}
+
+	if claimRecord.Address == "" {
+		return true
+	}
+
+	if !claimRecord.AmountClaim.IsNil() && claimRecord.AmountClaim.IsValid() && !claimRecord.AmountClaim.IsZero() {
+		return false
+	}
+
+	if !claimRecord.AmountVote.IsNil() && claimRecord.AmountVote.IsValid() && !claimRecord.AmountVote.IsZero() {
+		return false
+	}
+
+	if !claimRecord.AmountDelegate.IsNil() && claimRecord.AmountDelegate.IsValid() && !claimRecord.AmountDelegate.IsZero() {
+		return false
+	}
+
+	return true
+}

--- a/x/claim/types/claim_record_test.go
+++ b/x/claim/types/claim_record_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsEmpty tests IsEmpty method
+func TestIsEmpty(t *testing.T) {
+	// returns true if empty or nil
+	require.True(t, (&ClaimRecord{}).IsEmpty())
+	require.True(t, (&ClaimRecord{Address: ""}).IsEmpty())
+	require.True(t, (&ClaimRecord{Address: "foo"}).IsEmpty())
+	require.True(t, (&ClaimRecord{Address: "foo", AmountClaim: types.Coin{}}).IsEmpty())
+
+	// returns false if not empty
+	require.False(t, (&ClaimRecord{Address: "foo", AmountClaim: types.NewInt64Coin("foo", 1)}).IsEmpty())
+	require.False(t, (&ClaimRecord{Address: "foo", AmountVote: types.NewInt64Coin("foo", 1)}).IsEmpty())
+	require.False(t, (&ClaimRecord{Address: "foo", AmountDelegate: types.NewInt64Coin("foo", 1)}).IsEmpty())
+}


### PR DESCRIPTION
This PR flattens the ClaimRecord object to allow for more granular accounting of coin amounts per action and the merging of actions from a multi-chain user.

There are tests missing that will be required to validate the functionality, but require multiple keepers and balances to function (integration tests). 

Will document those tests cases in a issue to circle back once integration test framework is spun up  

integration tests list - https://github.com/arkeonetwork/arkeo/issues/42