### PR TITLE
adds event hooks for arkeo claims

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -425,10 +425,20 @@ func New(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
+	app.ClaimKeeper = claimmodulekeeper.NewKeeper(
+		appCodec,
+		keys[claimmoduletypes.StoreKey],
+		app.AccountKeeper,
+		app.BankKeeper,
+		keys[claimmoduletypes.MemStoreKey],
+		app.GetSubspace(claimmoduletypes.ModuleName),
+	)
+	claimModule := claimmodule.NewAppModule(appCodec, app.ClaimKeeper, app.AccountKeeper, app.BankKeeper)
+
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
 	app.StakingKeeper = *stakingKeeper.SetHooks(
-		stakingtypes.NewMultiStakingHooks(app.DistrKeeper.Hooks(), app.SlashingKeeper.Hooks()),
+		stakingtypes.NewMultiStakingHooks(app.DistrKeeper.Hooks(), app.SlashingKeeper.Hooks(), app.ClaimKeeper.Hooks()),
 	)
 
 	// ... other modules keepers
@@ -499,6 +509,12 @@ func New(
 		govConfig,
 	)
 
+	app.GovKeeper = *app.GovKeeper.SetHooks(
+		govtypes.NewMultiGovHooks(
+			app.ClaimKeeper.Hooks(),
+		),
+	)
+
 	app.ArkeoKeeper = *arkeomodulekeeper.NewKVStore(
 		appCodec,
 		keys[arkeomoduletypes.StoreKey],
@@ -510,16 +526,6 @@ func New(
 		semver.MustParse("0.0.0"),
 	)
 	arkeoModule := arkeomodule.NewAppModule(appCodec, app.ArkeoKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
-
-	app.ClaimKeeper = claimmodulekeeper.NewKeeper(
-		appCodec,
-		keys[claimmoduletypes.StoreKey],
-		app.AccountKeeper,
-		app.BankKeeper,
-		keys[claimmoduletypes.MemStoreKey],
-		app.GetSubspace(claimmoduletypes.ModuleName),
-	)
-	claimModule := claimmodule.NewAppModule(appCodec, app.ClaimKeeper, app.AccountKeeper, app.BankKeeper)
 
 	// this line is used by starport scaffolding # stargate/app/keeperDefinition
 

--- a/x/claim/keeper/hooks.go
+++ b/x/claim/keeper/hooks.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"github.com/arkeonetwork/arkeo/x/claim/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -19,21 +18,6 @@ func (k Keeper) Hooks() Hooks {
 
 var _ govtypes.GovHooks = Hooks{}
 var _ stakingtypes.StakingHooks = Hooks{}
-
-func (k Keeper) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) {
-	_, err := k.ClaimCoinsForAction(ctx, voterAddr.String(), types.ACTION_VOTE)
-	if err != nil {
-		k.Logger(ctx).Error("failed to claim coins for vote", "error", err.Error())
-	}
-}
-
-func (k Keeper) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
-	_, err := k.ClaimCoinsForAction(ctx, delAddr.String(), types.ACTION_DELEGATE)
-	if err != nil {
-		k.Logger(ctx).Error("failed to claim coins for delegate", "error", err.Error())
-	}
-	return nil
-}
 
 // governance hooks
 func (h Hooks) AfterProposalSubmission(ctx sdk.Context, proposalID uint64) {}

--- a/x/claim/keeper/hooks.go
+++ b/x/claim/keeper/hooks.go
@@ -1,0 +1,81 @@
+package keeper
+
+import (
+	"github.com/arkeonetwork/arkeo/x/claim/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// Hooks wrapper struct
+type Hooks struct {
+	k Keeper
+}
+
+// Return the wrapper struct
+func (k Keeper) Hooks() Hooks {
+	return Hooks{k}
+}
+
+var _ govtypes.GovHooks = Hooks{}
+var _ stakingtypes.StakingHooks = Hooks{}
+
+func (k Keeper) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) {
+	_, err := k.ClaimCoinsForAction(ctx, voterAddr.String(), types.ACTION_VOTE)
+	if err != nil {
+		k.Logger(ctx).Error("failed to claim coins for vote", "error", err.Error())
+	}
+}
+
+func (k Keeper) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	_, err := k.ClaimCoinsForAction(ctx, delAddr.String(), types.ACTION_DELEGATE)
+	if err != nil {
+		k.Logger(ctx).Error("failed to claim coins for delegate", "error", err.Error())
+	}
+	return nil
+}
+
+// governance hooks
+func (h Hooks) AfterProposalSubmission(ctx sdk.Context, proposalID uint64) {}
+func (h Hooks) AfterProposalDeposit(ctx sdk.Context, proposalID uint64, depositorAddr sdk.AccAddress) {
+}
+
+func (h Hooks) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) {
+	h.k.AfterProposalVote(ctx, proposalID, voterAddr)
+}
+func (h Hooks) AfterProposalFailedMinDeposit(ctx sdk.Context, proposalID uint64)  {}
+func (h Hooks) AfterProposalVotingPeriodEnded(ctx sdk.Context, proposalID uint64) {}
+
+// staking hooks
+func (h Hooks) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) error {
+	return nil
+}
+func (h Hooks) BeforeValidatorModified(ctx sdk.Context, valAddr sdk.ValAddress) error {
+	return nil
+}
+func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) error {
+	return nil
+}
+
+func (h Hooks) AfterValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) error {
+	return nil
+}
+func (h Hooks) AfterValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) error {
+	return nil
+}
+func (h Hooks) BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	return nil
+}
+func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	return nil
+}
+func (h Hooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	return nil
+}
+func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	_ = h.k.AfterDelegationModified(ctx, delAddr, valAddr)
+	return nil
+}
+func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) error {
+	return nil
+}

--- a/x/claim/keeper/keeper.go
+++ b/x/claim/keeper/keeper.go
@@ -50,3 +50,18 @@ func NewKeeper(
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
+
+func (k Keeper) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) {
+	_, err := k.ClaimCoinsForAction(ctx, voterAddr.String(), types.ACTION_VOTE)
+	if err != nil {
+		k.Logger(ctx).Error("failed to claim coins for vote", "error", err.Error())
+	}
+}
+
+func (k Keeper) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	_, err := k.ClaimCoinsForAction(ctx, delAddr.String(), types.ACTION_DELEGATE)
+	if err != nil {
+		k.Logger(ctx).Error("failed to claim coins for delegate", "error", err.Error())
+	}
+	return nil
+}


### PR DESCRIPTION
merge #45 and #46 first, rebase, and change to merge into master

This PR adds the needed event hooks into the claim module to respond to events from the staking and govt modules that will trigger claims for arkeo airdrops

needs additional integration tests and will add them to the list in #42 