### PR TITLE
Chore/more tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ignite/cli v0.24.0
-	github.com/ignite/modules v0.0.0-20220830145312-d006783a7a21
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.27.0
 	github.com/spf13/cast v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ignite/cli v0.24.0
+	github.com/ignite/modules v0.0.0-20220830145312-d006783a7a21
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.27.0
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -823,6 +823,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/ignite/cli v0.24.0 h1:2cggSIsT4MT9IIS4/8XqlwgekI0YWPMYeULLGrTgCUY=
 github.com/ignite/cli v0.24.0/go.mod h1:XlqM9HK751rcKZg7RfrP9KiJRAVi4XfZskhGnHPgLr0=
 github.com/ignite/modules v0.0.0-20220830145312-d006783a7a21 h1:2eqRFOwuBtP5prBIslVokLwLkXqekbY4cENDf2mEyxQ=
+github.com/ignite/modules v0.0.0-20220830145312-d006783a7a21/go.mod h1:9JK6kA34Z7qxM31BvZzPXR35JIlQNWyYHpJyGYcAPrc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/go.sum
+++ b/go.sum
@@ -823,7 +823,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/ignite/cli v0.24.0 h1:2cggSIsT4MT9IIS4/8XqlwgekI0YWPMYeULLGrTgCUY=
 github.com/ignite/cli v0.24.0/go.mod h1:XlqM9HK751rcKZg7RfrP9KiJRAVi4XfZskhGnHPgLr0=
 github.com/ignite/modules v0.0.0-20220830145312-d006783a7a21 h1:2eqRFOwuBtP5prBIslVokLwLkXqekbY4cENDf2mEyxQ=
-github.com/ignite/modules v0.0.0-20220830145312-d006783a7a21/go.mod h1:9JK6kA34Z7qxM31BvZzPXR35JIlQNWyYHpJyGYcAPrc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/proto/arkeo/claim/params.proto
+++ b/proto/arkeo/claim/params.proto
@@ -6,6 +6,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
+
 option go_package = "github.com/arkeonetwork/arkeo/x/claim/types";
 
 // Params defines the parameters for the module.

--- a/testutil/keeper/claim.go
+++ b/testutil/keeper/claim.go
@@ -20,7 +20,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
@@ -28,7 +27,16 @@ import (
 	tmdb "github.com/tendermint/tm-db"
 )
 
-func ClaimKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
+type (
+	TestKeepers struct {
+		ClaimKeeper   keeper.Keeper
+		AccountKeeper authkeeper.AccountKeeper
+		BankKeeper    bankkeeper.Keeper
+	}
+)
+
+// CreateTestClaimKeepers creates test keepers for claim module
+func CreateTestClaimKeepers(t testing.TB) (TestKeepers, sdk.Context) {
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	keyAcc := sdk.NewKVStoreKey(authtypes.StoreKey)
 	keyBank := sdk.NewKVStoreKey(banktypes.StoreKey)
@@ -49,7 +57,7 @@ func ClaimKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	registry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(registry)
 
-	paramsSubspace := typesparams.NewSubspace(cdc,
+	paramsSubspace := paramstypes.NewSubspace(cdc,
 		types.Amino,
 		storeKey,
 		memStoreKey,
@@ -90,5 +98,9 @@ func ClaimKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	}
 
 	k.SetParams(ctx, params)
-	return k, ctx
+	return TestKeepers{
+		ClaimKeeper:   k,
+		AccountKeeper: accountKeeper,
+		BankKeeper:    bankKeeper,
+	}, ctx
 }

--- a/testutil/utils/utils.go
+++ b/testutil/utils/utils.go
@@ -4,10 +4,48 @@ import (
 	"github.com/arkeonetwork/arkeo/common/cosmos"
 	"github.com/arkeonetwork/arkeo/x/arkeo/types"
 	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/std"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
+	"github.com/cosmos/cosmos-sdk/x/bank"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/cosmos-sdk/x/capability"
+	"github.com/cosmos/cosmos-sdk/x/crisis"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
+	"github.com/cosmos/cosmos-sdk/x/evidence"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/cosmos/cosmos-sdk/x/slashing"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	"github.com/cosmos/cosmos-sdk/x/upgrade"
+	"github.com/ignite/modules/x/mint"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
+)
+
+// ModuleBasics is a mock module basic manager for testing
+var ModuleBasics = module.NewBasicManager(
+	auth.AppModuleBasic{},
+	genutil.AppModuleBasic{},
+	bank.AppModuleBasic{},
+	capability.AppModuleBasic{},
+	staking.AppModuleBasic{},
+	mint.AppModuleBasic{},
+	distribution.AppModuleBasic{},
+	/*
+		gov.NewAppModuleBasic(
+			paramsclient.ProposalHandler, distrclient.ProposalHandler, upgradeclient.ProposalHandler, upgradeclient.CancelProposalHandler,
+		),
+	*/
+	params.AppModuleBasic{},
+	crisis.AppModuleBasic{},
+	slashing.AppModuleBasic{},
+	upgrade.AppModuleBasic{},
+	evidence.AppModuleBasic{},
+	vesting.AppModuleBasic{},
 )
 
 // create a codec used only for testing
@@ -19,6 +57,14 @@ func MakeTestCodec() *codec.LegacyAmino {
 	cosmos.RegisterCodec(cdc)
 	// codec.RegisterCrypto(cdc)
 	return cdc
+}
+
+func MakeTestMarshaler() codec.Codec {
+	interfaceRegistry := codectypes.NewInterfaceRegistry()
+	std.RegisterInterfaces(interfaceRegistry)
+	ModuleBasics.RegisterInterfaces(interfaceRegistry)
+	types.RegisterInterfaces(interfaceRegistry)
+	return codec.NewProtoCodec(interfaceRegistry)
 }
 
 // GetRandomArkeoAddress returns a random arkeo address for testing

--- a/x/arkeo/keeper/keeper_test.go
+++ b/x/arkeo/keeper/keeper_test.go
@@ -6,77 +6,31 @@ import (
 	"testing"
 
 	"github.com/arkeonetwork/arkeo/common/cosmos"
+	"github.com/arkeonetwork/arkeo/testutil/utils"
 	"github.com/arkeonetwork/arkeo/x/arkeo/types"
 
 	"github.com/blang/semver"
 	. "gopkg.in/check.v1"
 
-	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
-	"github.com/cosmos/cosmos-sdk/std"
 	"github.com/cosmos/cosmos-sdk/store"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
-	"github.com/cosmos/cosmos-sdk/x/bank"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/cosmos/cosmos-sdk/x/capability"
-	"github.com/cosmos/cosmos-sdk/x/crisis"
-	"github.com/cosmos/cosmos-sdk/x/distribution"
-	"github.com/cosmos/cosmos-sdk/x/evidence"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
-	"github.com/cosmos/cosmos-sdk/x/mint"
-	"github.com/cosmos/cosmos-sdk/x/params"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
-	"github.com/cosmos/cosmos-sdk/x/slashing"
-	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmdb "github.com/tendermint/tm-db"
 )
 
 func Test(t *testing.T) { TestingT(t) }
-
-// ModuleBasics is a mock module basic manager for testing
-var ModuleBasics = module.NewBasicManager(
-	auth.AppModuleBasic{},
-	genutil.AppModuleBasic{},
-	bank.AppModuleBasic{},
-	capability.AppModuleBasic{},
-	staking.AppModuleBasic{},
-	mint.AppModuleBasic{},
-	distribution.AppModuleBasic{},
-	/*
-		gov.NewAppModuleBasic(
-			paramsclient.ProposalHandler, distrclient.ProposalHandler, upgradeclient.ProposalHandler, upgradeclient.CancelProposalHandler,
-		),
-	*/
-	params.AppModuleBasic{},
-	crisis.AppModuleBasic{},
-	slashing.AppModuleBasic{},
-	upgrade.AppModuleBasic{},
-	evidence.AppModuleBasic{},
-	vesting.AppModuleBasic{},
-)
-
-func MakeTestMarshaler() codec.Codec {
-	interfaceRegistry := codectypes.NewInterfaceRegistry()
-	std.RegisterInterfaces(interfaceRegistry)
-	ModuleBasics.RegisterInterfaces(interfaceRegistry)
-	types.RegisterInterfaces(interfaceRegistry)
-	return codec.NewProtoCodec(interfaceRegistry)
-}
 
 func SetupKeeper(c *C) (cosmos.Context, Keeper) {
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
@@ -99,7 +53,7 @@ func SetupKeeper(c *C) (cosmos.Context, Keeper) {
 
 	encodingConfig := simappparams.MakeTestEncodingConfig()
 	types.RegisterInterfaces(encodingConfig.InterfaceRegistry)
-	cdc := MakeTestMarshaler()
+	cdc := utils.MakeTestMarshaler()
 	amino := encodingConfig.Amino
 
 	paramsSubspace := typesparams.NewSubspace(cdc,
@@ -165,7 +119,7 @@ func SetupKeeperWithStaking(c *C) (cosmos.Context, Keeper, stakingkeeper.Keeper)
 
 	encodingConfig := simappparams.MakeTestEncodingConfig()
 	types.RegisterInterfaces(encodingConfig.InterfaceRegistry)
-	cdc := MakeTestMarshaler()
+	cdc := utils.MakeTestMarshaler()
 	amino := encodingConfig.Amino
 
 	paramsSubspace := typesparams.NewSubspace(cdc,

--- a/x/claim/genesis_test.go
+++ b/x/claim/genesis_test.go
@@ -24,9 +24,9 @@ func TestGenesis(t *testing.T) {
 		Params: claimParams,
 	}
 
-	k, ctx := keepertest.ClaimKeeper(t)
-	claim.InitGenesis(ctx, k, genesisState)
-	got := claim.ExportGenesis(ctx, k)
+	testKeeepers, ctx := keepertest.CreateTestClaimKeepers(t)
+	claim.InitGenesis(ctx, testKeeepers.ClaimKeeper, genesisState)
+	got := claim.ExportGenesis(ctx, testKeeepers.ClaimKeeper)
 	require.NotNil(t, got)
 
 	addr1 := utils.GetRandomArkeoAddress().String()
@@ -65,9 +65,9 @@ func TestGenesis(t *testing.T) {
 			},
 		},
 	}
-	claim.InitGenesis(ctx, k, testGenesis)
+	claim.InitGenesis(ctx, testKeeepers.ClaimKeeper, testGenesis)
 
-	claimRecord, err := k.GetClaimRecord(ctx, addr2, types.ARKEO)
+	claimRecord, err := testKeeepers.ClaimKeeper.GetClaimRecord(ctx, addr2, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, claimRecord, types.ClaimRecord{
 		Address:        addr2,
@@ -77,11 +77,11 @@ func TestGenesis(t *testing.T) {
 		AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 1500000000),
 	})
 
-	claimableAmount, err := k.GetClaimableAmountForAction(ctx, addr2, types.ACTION_VOTE, types.ARKEO)
+	claimableAmount, err := testKeeepers.ClaimKeeper.GetClaimableAmountForAction(ctx, addr2, types.ACTION_VOTE, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, claimableAmount, sdk.NewInt64Coin(types.DefaultClaimDenom, 1500000000))
 
-	genesisExported := claim.ExportGenesis(ctx, k)
+	genesisExported := claim.ExportGenesis(ctx, testKeeepers.ClaimKeeper)
 	require.Equal(t, genesisExported.Params, testGenesis.Params)
 	require.ElementsMatch(t, genesisExported.ClaimRecords, testGenesis.ClaimRecords)
 }

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/pkg/errors"
 )
 
@@ -227,16 +226,6 @@ func (k Keeper) ClaimCoinsForAction(ctx sdk.Context, addr string, action types.A
 // 	amt := k.GetModuleAccountBalance(ctx)
 // 	return k.distrKeeper.FundCommunityPool(ctx, sdk.NewCoins(amt), moduleAccAddr)
 // }
-
-// CreateModuleAccount creates module account and mint coins to it
-func (k Keeper) CreateModuleAccount(ctx sdk.Context, amount sdk.Coin) {
-	moduleAcc := authtypes.NewEmptyModuleAccount(types.ModuleName, authtypes.Minter)
-	k.accountKeeper.SetModuleAccount(ctx, moduleAcc)
-	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(amount))
-	if err != nil {
-		panic(err) // module can not be set up correctly, should panic?
-	}
-}
 
 func chainToStorePrefix(chain types.Chain) []byte {
 	switch chain {

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -152,7 +152,7 @@ func (k Keeper) GetClaimableAmountForAction(ctx sdk.Context, addr string, action
 
 	// The entire airdrop has completed
 	if elapsedAirdropTime > params.DurationUntilDecay+params.DurationOfDecay {
-		return sdk.Coin{}, nil
+		return sdk.Coin{}, errors.New("airdrop has completed")
 	}
 
 	// Positive, since goneTime > params.DurationUntilDecay

--- a/x/claim/keeper/claim_test.go
+++ b/x/claim/keeper/claim_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGetClaimRecordForArkeo(t *testing.T) {
-	keeper, ctx := testkeeper.ClaimKeeper(t)
+	keepers, ctx := testkeeper.CreateTestClaimKeepers(t)
 
 	addr1 := utils.GetRandomArkeoAddress().String()
 	addr2 := utils.GetRandomArkeoAddress().String()
@@ -34,34 +34,34 @@ func TestGetClaimRecordForArkeo(t *testing.T) {
 			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
 		},
 	}
-	err := keeper.SetClaimRecords(ctx, claimRecords)
+	err := keepers.ClaimKeeper.SetClaimRecords(ctx, claimRecords)
 	require.NoError(t, err)
 
-	coins1, err := keeper.GetUserTotalClaimable(ctx, addr1, types.ARKEO)
+	coins1, err := keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr1, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, "300", coins1.Amount.String())
 
-	coins2, err := keeper.GetUserTotalClaimable(ctx, addr2, types.ARKEO)
+	coins2, err := keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr2, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, "600", coins2.Amount.String())
 
-	coins3, err := keeper.GetUserTotalClaimable(ctx, addr3, types.ARKEO)
+	coins3, err := keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr3, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, coins3, sdk.Coin{})
 
-	claimRecord, err := keeper.GetClaimRecord(ctx, addr3, types.ARKEO)
+	claimRecord, err := keepers.ClaimKeeper.GetClaimRecord(ctx, addr3, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, claimRecord, types.ClaimRecord{})
 
 	// get rewards amount per action
-	coins4, err := keeper.GetClaimableAmountForAction(ctx, addr1, types.ACTION_VOTE, types.ARKEO)
+	coins4, err := keepers.ClaimKeeper.GetClaimableAmountForAction(ctx, addr1, types.ACTION_VOTE, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, coins4.String(), sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 100)).String())
 
 }
 
 func TestGetClaimRecordForMutlipleChains(t *testing.T) {
-	keeper, ctx := testkeeper.ClaimKeeper(t)
+	keepers, ctx := testkeeper.CreateTestClaimKeepers(t)
 
 	addr1 := utils.GetRandomArkeoAddress().String()
 	addr2 := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random eth address
@@ -89,30 +89,30 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 		// 	ActionCompleted:        []bool{false, false},
 		// },
 	}
-	err := keeper.SetClaimRecords(ctx, claimRecords)
+	err := keepers.ClaimKeeper.SetClaimRecords(ctx, claimRecords)
 	require.NoError(t, err)
 
-	coins1, err := keeper.GetUserTotalClaimable(ctx, addr1, types.ARKEO)
+	coins1, err := keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr1, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, "300", coins1.Amount.String())
 
 	// user 1 should have no eth claim with an arkeo addy nor thor claims
-	coins1, err = keeper.GetUserTotalClaimable(ctx, addr1, types.ETHEREUM)
+	coins1, err = keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr1, types.ETHEREUM)
 	require.NoError(t, err)
 	require.Equal(t, coins1, sdk.Coin{})
-	coins1, err = keeper.GetUserTotalClaimable(ctx, addr1, types.THORCHAIN)
+	coins1, err = keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr1, types.THORCHAIN)
 	require.NoError(t, err)
 	require.Equal(t, coins1, sdk.Coin{})
 
 	// user 2 should have no arkeo claim nor thor claims, only eth
-	coins2, err := keeper.GetUserTotalClaimable(ctx, addr2, types.ETHEREUM)
+	coins2, err := keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr2, types.ETHEREUM)
 	require.NoError(t, err)
 	require.Equal(t, "600", coins2.Amount.String())
 
-	coins2, err = keeper.GetUserTotalClaimable(ctx, addr2, types.ARKEO)
+	coins2, err = keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr2, types.ARKEO)
 	require.NoError(t, err)
 	require.Equal(t, coins2, sdk.Coin{})
-	coins2, err = keeper.GetUserTotalClaimable(ctx, addr2, types.THORCHAIN)
+	coins2, err = keepers.ClaimKeeper.GetUserTotalClaimable(ctx, addr2, types.THORCHAIN)
 	require.NoError(t, err)
 	require.Equal(t, coins2, sdk.Coin{})
 
@@ -130,7 +130,7 @@ func TestGetClaimRecordForMutlipleChains(t *testing.T) {
 }
 
 func TestSetClaimRecord(t *testing.T) {
-	keeper, ctx := testkeeper.ClaimKeeper(t)
+	keepers, ctx := testkeeper.CreateTestClaimKeepers(t)
 
 	// confirm setting a claim record with a bad eth address fails
 	addr1Invalid := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98"  // random invalid eth address
@@ -142,11 +142,11 @@ func TestSetClaimRecord(t *testing.T) {
 		AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 	}
-	err := keeper.SetClaimRecord(ctx, claimRecord)
+	err := keepers.ClaimKeeper.SetClaimRecord(ctx, claimRecord)
 	require.Error(t, err)
 
 	claimRecord.Address = addr1Valid
-	err = keeper.SetClaimRecord(ctx, claimRecord)
+	err = keepers.ClaimKeeper.SetClaimRecord(ctx, claimRecord)
 	require.NoError(t, err)
 
 	// confirm setting a claim record with a bad arkeo address fails
@@ -159,16 +159,16 @@ func TestSetClaimRecord(t *testing.T) {
 		AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 		AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
 	}
-	err = keeper.SetClaimRecord(ctx, claimRecord)
+	err = keepers.ClaimKeeper.SetClaimRecord(ctx, claimRecord)
 	require.Error(t, err)
 
 	claimRecord.Address = addr2Valid
-	err = keeper.SetClaimRecord(ctx, claimRecord)
+	err = keepers.ClaimKeeper.SetClaimRecord(ctx, claimRecord)
 	require.NoError(t, err)
 }
 
 func TestGetAllClaimRecords(t *testing.T) {
-	keeper, ctx := testkeeper.ClaimKeeper(t)
+	keepers, ctx := testkeeper.CreateTestClaimKeepers(t)
 
 	addr1 := utils.GetRandomArkeoAddress().String()
 	addr2 := utils.GetRandomArkeoAddress().String()
@@ -198,11 +198,11 @@ func TestGetAllClaimRecords(t *testing.T) {
 			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
 		},
 	}
-	err := keeper.SetClaimRecords(ctx, claimRecords)
+	err := keepers.ClaimKeeper.SetClaimRecords(ctx, claimRecords)
 	require.NoError(t, err)
 
 	// confirm all claims are returned
-	claims, err := keeper.GetAllClaimRecords(ctx)
+	claims, err := keepers.ClaimKeeper.GetAllClaimRecords(ctx)
 	require.NoError(t, err)
 	require.Equal(t, len(claims), len(claimRecords))
 }

--- a/x/claim/keeper/msg_server_claim_arkeo.go
+++ b/x/claim/keeper/msg_server_claim_arkeo.go
@@ -16,8 +16,8 @@ func (k msgServer) ClaimArkeo(goCtx context.Context, msg *types.MsgClaimArkeo) (
 		return nil, errors.Wrapf(err, "failed to get claim record for %s", msg.Creator)
 	}
 
-	if arkeoClaim == (types.ClaimRecord{}) || arkeoClaim.AmountClaim.IsNil() || arkeoClaim.AmountClaim.IsZero() {
-		return nil, errors.Wrapf(err, "no claimable amount for %s", msg.Creator)
+	if arkeoClaim.IsEmpty() || arkeoClaim.AmountClaim.IsZero() {
+		return nil, errors.Errorf("no claimable amount for %s", msg.Creator)
 	}
 
 	_, err = k.ClaimCoinsForAction(ctx, msg.Creator, types.ACTION_CLAIM)

--- a/x/claim/keeper/msg_server_claim_arkeo_test.go
+++ b/x/claim/keeper/msg_server_claim_arkeo_test.go
@@ -1,0 +1,67 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/arkeonetwork/arkeo/testutil/utils"
+	"github.com/arkeonetwork/arkeo/x/claim/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimArkeo(t *testing.T) {
+	msgServer, keepers, ctx := setupMsgServer(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	addrArkeo := utils.GetRandomArkeoAddress()
+
+	claimRecord := types.ClaimRecord{
+		Chain:          types.ARKEO,
+		Address:        addrArkeo.String(),
+		AmountClaim:    sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		AmountVote:     sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+		AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 100),
+	}
+	err := keepers.ClaimKeeper.SetClaimRecord(sdkCtx, claimRecord)
+	require.NoError(t, err)
+
+	// mint coins to module account
+	err = keepers.BankKeeper.MintCoins(sdkCtx, types.ModuleName, sdk.NewCoins(sdk.NewInt64Coin(types.DefaultClaimDenom, 10000)))
+	require.NoError(t, err)
+
+	// get balance of arkeo address before claim
+	balanceBefore := keepers.BankKeeper.GetBalance(sdkCtx, addrArkeo, types.DefaultClaimDenom)
+
+	claimMessage := types.MsgClaimArkeo{
+		Creator: addrArkeo.String(),
+	}
+	_, err = msgServer.ClaimArkeo(ctx, &claimMessage)
+	require.NoError(t, err)
+
+	// check if claimrecord is updated
+	claimRecord, err = keepers.ClaimKeeper.GetClaimRecord(sdkCtx, addrArkeo.String(), types.ARKEO)
+	require.NoError(t, err)
+	require.True(t, !claimRecord.IsEmpty())
+
+	require.Equal(t, claimRecord.Address, addrArkeo.String())
+	require.Equal(t, claimRecord.Chain, types.ARKEO)
+	require.True(t, claimRecord.AmountClaim.IsZero()) // nothing to claim for claim action
+	require.Equal(t, claimRecord.AmountVote, sdk.NewInt64Coin(types.DefaultClaimDenom, 100))
+	require.Equal(t, claimRecord.AmountDelegate, sdk.NewInt64Coin(types.DefaultClaimDenom, 100))
+
+	// confirm balance increased by expected amount.
+	balanceAfter := keepers.BankKeeper.GetBalance(sdkCtx, addrArkeo, types.DefaultClaimDenom)
+	require.Equal(t, balanceAfter.Sub(balanceBefore), sdk.NewInt64Coin(types.DefaultClaimDenom, 100))
+
+	// attempt to claim again to ensure it fails.
+	_, err = msgServer.ClaimArkeo(ctx, &claimMessage)
+	require.Error(t, err)
+
+	// ensure claim Arkeo fails from address with no claim record
+	addrArkeo2 := utils.GetRandomArkeoAddress()
+	claimMessage2 := types.MsgClaimArkeo{
+		Creator: addrArkeo2.String(),
+	}
+	_, err = msgServer.ClaimArkeo(ctx, &claimMessage2)
+	require.Error(t, err)
+}

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -25,7 +25,7 @@ func (k msgServer) ClaimEth(goCtx context.Context, msg *types.MsgClaimEth) (*typ
 	}
 
 	if ethClaim.IsEmpty() || ethClaim.AmountClaim.IsZero() {
-		return nil, errors.Wrapf(err, "no claimable amount for %s", msg.EthAddress)
+		return nil, errors.Errorf("no claimable amount for %s", msg.EthAddress)
 	}
 	totalAmountClaimable := getInitialClaimableAmountTotal(ethClaim)
 
@@ -189,8 +189,23 @@ func mergeClaimRecords(claimA types.ClaimRecord, claimB types.ClaimRecord) (type
 		return types.ClaimRecord{}, errors.New("cannot merge claims for different chains")
 	}
 
-	claimA.AmountClaim = claimA.AmountClaim.Add(claimB.AmountClaim)
-	claimA.AmountDelegate = claimA.AmountDelegate.Add(claimB.AmountDelegate)
-	claimA.AmountVote = claimA.AmountVote.Add(claimB.AmountVote)
+	if claimA.AmountClaim.IsNil() || !claimA.AmountClaim.IsValid() {
+		claimA.AmountClaim = claimB.AmountClaim
+	} else {
+		claimA.AmountClaim = claimA.AmountClaim.Add(claimB.AmountClaim)
+	}
+
+	if claimA.AmountDelegate.IsNil() || !claimA.AmountDelegate.IsValid() {
+		claimA.AmountDelegate = claimB.AmountDelegate
+	} else {
+		claimA.AmountDelegate = claimA.AmountDelegate.Add(claimB.AmountDelegate)
+	}
+
+	if claimA.AmountVote.IsNil() || !claimA.AmountVote.IsValid() {
+		claimA.AmountVote = claimB.AmountVote
+	} else {
+		claimA.AmountVote = claimA.AmountVote.Add(claimB.AmountVote)
+	}
+
 	return claimA, nil
 }

--- a/x/claim/keeper/msg_server_test.go
+++ b/x/claim/keeper/msg_server_test.go
@@ -11,6 +11,6 @@ import (
 )
 
 func setupMsgServer(t testing.TB) (types.MsgServer, keeper.Keeper, context.Context) {
-	k, ctx := keepertest.ClaimKeeper(t)
-	return keeper.NewMsgServerImpl(k), k, sdk.WrapSDKContext(ctx)
+	keepers, ctx := keepertest.CreateTestClaimKeepers(t)
+	return keeper.NewMsgServerImpl(keepers.ClaimKeeper), keepers.ClaimKeeper, sdk.WrapSDKContext(ctx)
 }

--- a/x/claim/keeper/msg_server_test.go
+++ b/x/claim/keeper/msg_server_test.go
@@ -10,7 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func setupMsgServer(t testing.TB) (types.MsgServer, keeper.Keeper, context.Context) {
+func setupMsgServer(t testing.TB) (types.MsgServer, keepertest.TestKeepers, context.Context) {
 	keepers, ctx := keepertest.CreateTestClaimKeepers(t)
-	return keeper.NewMsgServerImpl(keepers.ClaimKeeper), keepers.ClaimKeeper, sdk.WrapSDKContext(ctx)
+	return keeper.NewMsgServerImpl(keepers.ClaimKeeper), keepers, sdk.WrapSDKContext(ctx)
 }

--- a/x/claim/keeper/params_test.go
+++ b/x/claim/keeper/params_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestGetParams(t *testing.T) {
-	k, ctx := testkeeper.ClaimKeeper(t)
+	keepers, ctx := testkeeper.CreateTestClaimKeepers(t)
 	params := types.DefaultParams()
 	params.ClaimDenom = "Test!"
-	k.SetParams(ctx, params)
-	got := k.GetParams(ctx)
+	keepers.ClaimKeeper.SetParams(ctx, params)
+	got := keepers.ClaimKeeper.GetParams(ctx)
 	require.EqualValues(t, params, got)
 }

--- a/x/claim/keeper/query_claim_record_test.go
+++ b/x/claim/keeper/query_claim_record_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClaimRecord(t *testing.T) {
-	keeper, ctx := testkeeper.ClaimKeeper(t)
+	keepers, ctx := testkeeper.CreateTestClaimKeepers(t)
 
 	addr1 := utils.GetRandomArkeoAddress().String()
 	addr2 := "0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5" // random eth address
@@ -32,14 +32,14 @@ func TestClaimRecord(t *testing.T) {
 			AmountDelegate: sdk.NewInt64Coin(types.DefaultClaimDenom, 200),
 		},
 	}
-	err := keeper.SetClaimRecords(ctx, claimRecords)
+	err := keepers.ClaimKeeper.SetClaimRecords(ctx, claimRecords)
 	require.NoError(t, err)
 
 	req := types.QueryClaimRecordRequest{
 		Address: addr1,
 		Chain:   types.ARKEO,
 	}
-	resp, err := keeper.ClaimRecord(ctx, &req)
+	resp, err := keepers.ClaimKeeper.ClaimRecord(ctx, &req)
 	require.NoError(t, err)
 	require.Equal(t, *resp.ClaimRecord, claimRecords[0])
 
@@ -47,7 +47,7 @@ func TestClaimRecord(t *testing.T) {
 		Address: addr2,
 		Chain:   types.ETHEREUM,
 	}
-	resp, err = keeper.ClaimRecord(ctx, &req)
+	resp, err = keepers.ClaimKeeper.ClaimRecord(ctx, &req)
 	require.NoError(t, err)
 	require.Equal(t, *resp.ClaimRecord, claimRecords[1])
 
@@ -55,6 +55,6 @@ func TestClaimRecord(t *testing.T) {
 		Address: "invalid address",
 		Chain:   types.ETHEREUM,
 	}
-	resp, _ = keeper.ClaimRecord(ctx, &req)
+	resp, _ = keepers.ClaimKeeper.ClaimRecord(ctx, &req)
 	require.Equal(t, *resp.ClaimRecord, types.ClaimRecord{})
 }

--- a/x/claim/keeper/query_params_test.go
+++ b/x/claim/keeper/query_params_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestParamsQuery(t *testing.T) {
-	keeper, ctx := testkeeper.ClaimKeeper(t)
+	keepers, ctx := testkeeper.CreateTestClaimKeepers(t)
 	wctx := sdk.WrapSDKContext(ctx)
 	params := types.DefaultParams()
-	keeper.SetParams(ctx, params)
+	keepers.ClaimKeeper.SetParams(ctx, params)
 
-	response, err := keeper.Params(wctx, &types.QueryParamsRequest{})
+	response, err := keepers.ClaimKeeper.Params(wctx, &types.QueryParamsRequest{})
 	require.NoError(t, err)
 	require.Equal(t, &types.QueryParamsResponse{Params: params}, response)
 }


### PR DESCRIPTION
Closes #42 

Added an easy way to get access to other keepers in the Claim module tests until we get better integration test support in SDK 0.47.0

This also adds a few bug fixes discovered in the more thorough testing. 