### PR TITLE
Add "add-claim" feature for testnet

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -568,6 +568,8 @@ paths:
                       custom method
 
                       signatures required by gogoproto.
+                  is_transferable:
+                    type: boolean
                 title: A Claim Records is the metadata of claim data per address
         default:
           description: An unexpected error response.
@@ -46074,7 +46076,11 @@ definitions:
 
           NOTE: The amount field is an Int which implements the custom method
           signatures required by gogoproto.
+      is_transferable:
+        type: boolean
     title: A Claim Records is the metadata of claim data per address
+  arkeonetwork.arkeo.claim.MsgAddClaimResponse:
+    type: object
   arkeonetwork.arkeo.claim.MsgClaimArkeoResponse:
     type: object
   arkeonetwork.arkeo.claim.MsgClaimEthResponse:
@@ -46171,6 +46177,8 @@ definitions:
               method
 
               signatures required by gogoproto.
+          is_transferable:
+            type: boolean
         title: A Claim Records is the metadata of claim data per address
   arkeonetwork.arkeo.claim.QueryParamsResponse:
     type: object

--- a/go.mod
+++ b/go.mod
@@ -113,6 +113,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.1 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -757,6 +757,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.1 h1:I6ITHEanAwjB0FvaxmGm8pKqmCLR7QIe05ZmO4QAXMw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.1/go.mod h1:gYC+WX4YJFarA2ie73G2epzt7TBWpo9pzcBnK1g0MSw=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=

--- a/proto/arkeo/arkeo/keeper.proto
+++ b/proto/arkeo/arkeo/keeper.proto
@@ -12,8 +12,10 @@ enum ProviderStatus {
 }
 
 message Provider {
-  string pub_key = 1 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
-  int32 chain = 2 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.Chain" ];
+  string pub_key = 1
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  int32 chain = 2
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.Chain" ];
   string metadataURI = 3;
   uint64 metadata_nonce = 4;
   ProviderStatus status = 5;
@@ -35,10 +37,14 @@ enum ContractType {
 }
 
 message Contract {
-  string provider_pub_key = 1 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
-  int32 chain = 2 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.Chain" ];
-  string client = 3 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
-  string delegate = 4 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string provider_pub_key = 1
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  int32 chain = 2
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.Chain" ];
+  string client = 3
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string delegate = 4
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   ContractType type = 5;
   int64 height = 6;
   int64 duration = 7;
@@ -58,9 +64,12 @@ message Contract {
 }
 
 message ContractExpiration {
-  string provider_pub_key = 1 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
-  int32 chain = 2 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.Chain" ];
-  string client = 3 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string provider_pub_key = 1
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  int32 chain = 2
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.Chain" ];
+  string client = 3
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
 }
 
 message ContractExpirationSet {

--- a/proto/arkeo/arkeo/tx.proto
+++ b/proto/arkeo/arkeo/tx.proto
@@ -20,7 +20,8 @@ service Msg {
 
 message MsgBondProvider {
   string creator = 1;
-  string pub_key = 2 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string pub_key = 2
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   string chain = 3;
   string bond = 4 [
     (cosmos_proto.scalar) = "cosmos.Int",
@@ -33,7 +34,8 @@ message MsgBondProviderResponse {}
 
 message MsgModProvider {
   string creator = 1;
-  string pub_key = 2 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string pub_key = 2
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   string chain = 3;
   string metadataURI = 4;
   uint64 metadataNonce = 5;
@@ -48,10 +50,13 @@ message MsgModProviderResponse {}
 
 message MsgOpenContract {
   string creator = 1;
-  string pub_key = 2 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string pub_key = 2
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   string chain = 3;
-  string client = 4 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
-  string delegate = 5 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string client = 4
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string delegate = 5
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   ContractType cType = 6;
   int64 duration = 7;
   int64 rate = 8;
@@ -66,19 +71,24 @@ message MsgOpenContractResponse {}
 
 message MsgCloseContract {
   string creator = 1;
-  string pub_key = 2 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string pub_key = 2
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   string chain = 3;
-  string client = 4 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
-  string delegate = 5 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string client = 4
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string delegate = 5
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
 }
 
 message MsgCloseContractResponse {}
 
 message MsgClaimContractIncome {
   string creator = 1;
-  string pub_key = 2 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string pub_key = 2
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   string chain = 3;
-  string spender = 4 [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
+  string spender = 4
+      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   bytes signature = 5;
   int64 nonce = 6;
   int64 height = 7;

--- a/proto/arkeo/claim/claim_record.proto
+++ b/proto/arkeo/claim/claim_record.proto
@@ -22,7 +22,6 @@ enum Chain {
   ETHEREUM = 1;
 }
 
-
 // A Claim Records is the metadata of claim data per address
 message ClaimRecord {
 
@@ -31,9 +30,19 @@ message ClaimRecord {
   // arkeo address of claim user
   string address = 2 [ (gogoproto.moretags) = "yaml:\"address\"" ];
 
-  // claimable amount per action (claim, vote, delegate - changed to 0 after action completed)
-  cosmos.base.v1beta1.Coin amount_claim = 3 [(gogoproto.nullable) = false,  (gogoproto.moretags) = "yaml:\"amount_claim\""];
-  cosmos.base.v1beta1.Coin amount_vote = 4 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"amount_vote\""];
-  cosmos.base.v1beta1.Coin amount_delegate = 5 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"amount_delegate\""];
+  // claimable amount per action (claim, vote, delegate - changed to 0 after
+  // action completed)
+  cosmos.base.v1beta1.Coin amount_claim = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.moretags) = "yaml:\"amount_claim\""
+  ];
+  cosmos.base.v1beta1.Coin amount_vote = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.moretags) = "yaml:\"amount_vote\""
+  ];
+  cosmos.base.v1beta1.Coin amount_delegate = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.moretags) = "yaml:\"amount_delegate\""
+  ];
   bool is_transferable = 6;
 }

--- a/proto/arkeo/claim/genesis.proto
+++ b/proto/arkeo/claim/genesis.proto
@@ -10,14 +10,14 @@ option go_package = "github.com/arkeonetwork/arkeo/x/claim/types";
 
 // GenesisState defines the claim module's genesis state.
 message GenesisState {
-  
+
   // balance of the claim module's account
   cosmos.base.v1beta1.Coin module_account_balance = 1 [
     (gogoproto.moretags) = "yaml:\"module_account_balance\"",
     (gogoproto.nullable) = false
   ];
-  
-  Params params = 2 [(gogoproto.nullable) = false];
+
+  Params params = 2 [ (gogoproto.nullable) = false ];
 
   // list of claim records, one for every airdrop recipient
   repeated ClaimRecord claim_records = 3 [

--- a/proto/arkeo/claim/params.proto
+++ b/proto/arkeo/claim/params.proto
@@ -6,7 +6,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-
 option go_package = "github.com/arkeonetwork/arkeo/x/claim/types";
 
 // Params defines the parameters for the module.
@@ -30,8 +29,9 @@ message Params {
   ];
 
   // denom of claimable asset
-  string claim_denom = 4;  
+  string claim_denom = 4;
   // uarkeo to distribute to arkeo account for gas to make claiming easier
-  cosmos.base.v1beta1.Coin initial_gas_amount = 5  [ (gogoproto.moretags) = "yaml:\"initial_gas_amount\""];
+  cosmos.base.v1beta1.Coin initial_gas_amount = 5
+      [ (gogoproto.moretags) = "yaml:\"initial_gas_amount\"" ];
   ;
 }

--- a/proto/arkeo/claim/query.proto
+++ b/proto/arkeo/claim/query.proto
@@ -12,17 +12,16 @@ option go_package = "github.com/arkeonetwork/arkeo/x/claim/types";
 
 // Query defines the gRPC querier service.
 service Query {
-  
+
   // Parameters queries the parameters of the module.
-  rpc Params (QueryParamsRequest) returns (QueryParamsResponse) {
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (google.api.http).get = "/arkeonetwork/arkeo/claim/params";
-  
   }
-  
+
   // Queries a list of ClaimRecord items.
-  rpc ClaimRecord (QueryClaimRecordRequest) returns (QueryClaimRecordResponse) {
-    option (google.api.http).get = "/arkeonetwork/arkeo/claim/claimrecord/{address}";
-  
+  rpc ClaimRecord(QueryClaimRecordRequest) returns (QueryClaimRecordResponse) {
+    option (google.api.http).get =
+        "/arkeonetwork/arkeo/claim/claimrecord/{address}";
   }
 }
 // QueryParamsRequest is request type for the Query/Params RPC method.
@@ -30,9 +29,9 @@ message QueryParamsRequest {}
 
 // QueryParamsResponse is response type for the Query/Params RPC method.
 message QueryParamsResponse {
-  
+
   // params holds all the parameters of this module.
-  Params params = 1 [(gogoproto.nullable) = false];
+  Params params = 1 [ (gogoproto.nullable) = false ];
 }
 
 message QueryClaimRecordRequest {
@@ -40,7 +39,4 @@ message QueryClaimRecordRequest {
   Chain chain = 2;
 }
 
-message QueryClaimRecordResponse {
-  ClaimRecord claim_record = 1;
-}
-
+message QueryClaimRecordResponse { ClaimRecord claim_record = 1; }

--- a/proto/arkeo/claim/tx.proto
+++ b/proto/arkeo/claim/tx.proto
@@ -1,27 +1,27 @@
 syntax = "proto3";
 
 package arkeonetwork.arkeo.claim;
-
+import "arkeo/claim/claim_record.proto";
 option go_package = "github.com/arkeonetwork/arkeo/x/claim/types";
 
 // Msg defines the Msg service.
 service Msg {
-  rpc ClaimEth   (MsgClaimEth  ) returns (MsgClaimEthResponse  );
-  rpc ClaimArkeo (MsgClaimArkeo) returns (MsgClaimArkeoResponse);
+  rpc ClaimEth(MsgClaimEth) returns (MsgClaimEthResponse);
+  rpc ClaimArkeo(MsgClaimArkeo) returns (MsgClaimArkeoResponse);
   rpc TransferClaim(MsgTransferClaim) returns (MsgTransferClaimResponse);
-// this line is used by starport scaffolding # proto/tx/rpc
+
+  // this line is used by starport scaffolding # proto/tx/rpc
+  rpc AddClaim(MsgAddClaim) returns (MsgAddClaimResponse);
 }
 message MsgClaimEth {
-  string creator     = 1;
+  string creator = 1;
   string eth_address = 2; // the adress the claim is for
-  string signature   = 3; // EIP712 signature that has to be signed by ethAddress
+  string signature = 3; // EIP712 signature that has to be signed by ethAddress
 }
 
 message MsgClaimEthResponse {}
 
-message MsgClaimArkeo {
-  string creator = 1;
-}
+message MsgClaimArkeo { string creator = 1; }
 
 message MsgClaimArkeoResponse {}
 
@@ -30,7 +30,15 @@ message MsgTransferClaim {
   string toAddress = 2;
 }
 
-message MsgTransferClaimResponse {
+message MsgTransferClaimResponse {}
+
+message MsgAddClaim {
+  string creator = 1;
+  Chain chain = 2;
+  string address = 3;
+  int64 amount = 4;
 }
+
+message MsgAddClaimResponse {}
 
 // this line is used by starport scaffolding # proto/tx/message

--- a/proto/arkeo/claim/tx.proto
+++ b/proto/arkeo/claim/tx.proto
@@ -9,9 +9,8 @@ service Msg {
   rpc ClaimEth(MsgClaimEth) returns (MsgClaimEthResponse);
   rpc ClaimArkeo(MsgClaimArkeo) returns (MsgClaimArkeoResponse);
   rpc TransferClaim(MsgTransferClaim) returns (MsgTransferClaimResponse);
-
-  // this line is used by starport scaffolding # proto/tx/rpc
   rpc AddClaim(MsgAddClaim) returns (MsgAddClaimResponse);
+  // this line is used by starport scaffolding # proto/tx/rpc
 }
 message MsgClaimEth {
   string creator = 1;

--- a/ts-client/arkeonetwork.arkeo.claim/module.ts
+++ b/ts-client/arkeonetwork.arkeo.claim/module.ts
@@ -7,16 +7,18 @@ import { msgTypes } from './registry';
 import { IgniteClient } from "../client"
 import { MissingWalletError } from "../helpers"
 import { Api } from "./rest";
-import { MsgClaimArkeo } from "./types/arkeo/claim/tx";
+import { MsgAddClaim } from "./types/arkeo/claim/tx";
 import { MsgClaimEth } from "./types/arkeo/claim/tx";
+import { MsgClaimArkeo } from "./types/arkeo/claim/tx";
+import { MsgTransferClaim } from "./types/arkeo/claim/tx";
 
 import { ClaimRecord as typeClaimRecord} from "./types"
 import { Params as typeParams} from "./types"
 
-export { MsgClaimArkeo, MsgClaimEth };
+export { MsgAddClaim, MsgClaimEth, MsgClaimArkeo, MsgTransferClaim };
 
-type sendMsgClaimArkeoParams = {
-  value: MsgClaimArkeo,
+type sendMsgAddClaimParams = {
+  value: MsgAddClaim,
   fee?: StdFee,
   memo?: string
 };
@@ -27,13 +29,33 @@ type sendMsgClaimEthParams = {
   memo?: string
 };
 
+type sendMsgClaimArkeoParams = {
+  value: MsgClaimArkeo,
+  fee?: StdFee,
+  memo?: string
+};
+
+type sendMsgTransferClaimParams = {
+  value: MsgTransferClaim,
+  fee?: StdFee,
+  memo?: string
+};
+
+
+type msgAddClaimParams = {
+  value: MsgAddClaim,
+};
+
+type msgClaimEthParams = {
+  value: MsgClaimEth,
+};
 
 type msgClaimArkeoParams = {
   value: MsgClaimArkeo,
 };
 
-type msgClaimEthParams = {
-  value: MsgClaimEth,
+type msgTransferClaimParams = {
+  value: MsgTransferClaim,
 };
 
 
@@ -66,17 +88,17 @@ export const txClient = ({ signer, prefix, addr }: TxClientOptions = { addr: "ht
 
   return {
 		
-		async sendMsgClaimArkeo({ value, fee, memo }: sendMsgClaimArkeoParams): Promise<DeliverTxResponse> {
+		async sendMsgAddClaim({ value, fee, memo }: sendMsgAddClaimParams): Promise<DeliverTxResponse> {
 			if (!signer) {
-					throw new Error('TxClient:sendMsgClaimArkeo: Unable to sign Tx. Signer is not present.')
+					throw new Error('TxClient:sendMsgAddClaim: Unable to sign Tx. Signer is not present.')
 			}
 			try {			
 				const { address } = (await signer.getAccounts())[0]; 
 				const signingClient = await SigningStargateClient.connectWithSigner(addr,signer,{registry, prefix});
-				let msg = this.msgClaimArkeo({ value: MsgClaimArkeo.fromPartial(value) })
+				let msg = this.msgAddClaim({ value: MsgAddClaim.fromPartial(value) })
 				return await signingClient.signAndBroadcast(address, [msg], fee ? fee : defaultFee, memo)
 			} catch (e: any) {
-				throw new Error('TxClient:sendMsgClaimArkeo: Could not broadcast Tx: '+ e.message)
+				throw new Error('TxClient:sendMsgAddClaim: Could not broadcast Tx: '+ e.message)
 			}
 		},
 		
@@ -94,6 +116,50 @@ export const txClient = ({ signer, prefix, addr }: TxClientOptions = { addr: "ht
 			}
 		},
 		
+		async sendMsgClaimArkeo({ value, fee, memo }: sendMsgClaimArkeoParams): Promise<DeliverTxResponse> {
+			if (!signer) {
+					throw new Error('TxClient:sendMsgClaimArkeo: Unable to sign Tx. Signer is not present.')
+			}
+			try {			
+				const { address } = (await signer.getAccounts())[0]; 
+				const signingClient = await SigningStargateClient.connectWithSigner(addr,signer,{registry, prefix});
+				let msg = this.msgClaimArkeo({ value: MsgClaimArkeo.fromPartial(value) })
+				return await signingClient.signAndBroadcast(address, [msg], fee ? fee : defaultFee, memo)
+			} catch (e: any) {
+				throw new Error('TxClient:sendMsgClaimArkeo: Could not broadcast Tx: '+ e.message)
+			}
+		},
+		
+		async sendMsgTransferClaim({ value, fee, memo }: sendMsgTransferClaimParams): Promise<DeliverTxResponse> {
+			if (!signer) {
+					throw new Error('TxClient:sendMsgTransferClaim: Unable to sign Tx. Signer is not present.')
+			}
+			try {			
+				const { address } = (await signer.getAccounts())[0]; 
+				const signingClient = await SigningStargateClient.connectWithSigner(addr,signer,{registry, prefix});
+				let msg = this.msgTransferClaim({ value: MsgTransferClaim.fromPartial(value) })
+				return await signingClient.signAndBroadcast(address, [msg], fee ? fee : defaultFee, memo)
+			} catch (e: any) {
+				throw new Error('TxClient:sendMsgTransferClaim: Could not broadcast Tx: '+ e.message)
+			}
+		},
+		
+		
+		msgAddClaim({ value }: msgAddClaimParams): EncodeObject {
+			try {
+				return { typeUrl: "/arkeonetwork.arkeo.claim.MsgAddClaim", value: MsgAddClaim.fromPartial( value ) }  
+			} catch (e: any) {
+				throw new Error('TxClient:MsgAddClaim: Could not create message: ' + e.message)
+			}
+		},
+		
+		msgClaimEth({ value }: msgClaimEthParams): EncodeObject {
+			try {
+				return { typeUrl: "/arkeonetwork.arkeo.claim.MsgClaimEth", value: MsgClaimEth.fromPartial( value ) }  
+			} catch (e: any) {
+				throw new Error('TxClient:MsgClaimEth: Could not create message: ' + e.message)
+			}
+		},
 		
 		msgClaimArkeo({ value }: msgClaimArkeoParams): EncodeObject {
 			try {
@@ -103,11 +169,11 @@ export const txClient = ({ signer, prefix, addr }: TxClientOptions = { addr: "ht
 			}
 		},
 		
-		msgClaimEth({ value }: msgClaimEthParams): EncodeObject {
+		msgTransferClaim({ value }: msgTransferClaimParams): EncodeObject {
 			try {
-				return { typeUrl: "/arkeonetwork.arkeo.claim.MsgClaimEth", value: MsgClaimEth.fromPartial( value ) }  
+				return { typeUrl: "/arkeonetwork.arkeo.claim.MsgTransferClaim", value: MsgTransferClaim.fromPartial( value ) }  
 			} catch (e: any) {
-				throw new Error('TxClient:MsgClaimEth: Could not create message: ' + e.message)
+				throw new Error('TxClient:MsgTransferClaim: Could not create message: ' + e.message)
 			}
 		},
 		

--- a/ts-client/arkeonetwork.arkeo.claim/registry.ts
+++ b/ts-client/arkeonetwork.arkeo.claim/registry.ts
@@ -1,9 +1,11 @@
 import { GeneratedType } from "@cosmjs/proto-signing";
+import { MsgAddClaim } from "./types/arkeo/claim/tx";
 import { MsgClaimEth } from "./types/arkeo/claim/tx";
 import { MsgClaimArkeo } from "./types/arkeo/claim/tx";
 import { MsgTransferClaim } from "./types/arkeo/claim/tx";
 
 const msgTypes: Array<[string, GeneratedType]>  = [
+    ["/arkeonetwork.arkeo.claim.MsgAddClaim", MsgAddClaim],
     ["/arkeonetwork.arkeo.claim.MsgClaimEth", MsgClaimEth],
     ["/arkeonetwork.arkeo.claim.MsgClaimArkeo", MsgClaimArkeo],
     ["/arkeonetwork.arkeo.claim.MsgTransferClaim", MsgTransferClaim],

--- a/ts-client/arkeonetwork.arkeo.claim/rest.ts
+++ b/ts-client/arkeonetwork.arkeo.claim/rest.ts
@@ -44,7 +44,10 @@ export interface ClaimClaimRecord {
    * signatures required by gogoproto.
    */
   amount_delegate?: V1Beta1Coin
+  is_transferable?: boolean
 }
+
+export type ClaimMsgAddClaimResponse = object
 
 export type ClaimMsgClaimArkeoResponse = object
 

--- a/ts-client/arkeonetwork.arkeo.claim/types/arkeo/claim/claim_record.ts
+++ b/ts-client/arkeonetwork.arkeo.claim/types/arkeo/claim/claim_record.ts
@@ -86,10 +86,18 @@ export interface ClaimRecord {
   amountClaim: Coin | undefined;
   amountVote: Coin | undefined;
   amountDelegate: Coin | undefined;
+  isTransferable: boolean;
 }
 
 function createBaseClaimRecord(): ClaimRecord {
-  return { chain: 0, address: "", amountClaim: undefined, amountVote: undefined, amountDelegate: undefined };
+  return {
+    chain: 0,
+    address: "",
+    amountClaim: undefined,
+    amountVote: undefined,
+    amountDelegate: undefined,
+    isTransferable: false,
+  };
 }
 
 export const ClaimRecord = {
@@ -108,6 +116,9 @@ export const ClaimRecord = {
     }
     if (message.amountDelegate !== undefined) {
       Coin.encode(message.amountDelegate, writer.uint32(42).fork()).ldelim();
+    }
+    if (message.isTransferable === true) {
+      writer.uint32(48).bool(message.isTransferable);
     }
     return writer;
   },
@@ -134,6 +145,9 @@ export const ClaimRecord = {
         case 5:
           message.amountDelegate = Coin.decode(reader, reader.uint32());
           break;
+        case 6:
+          message.isTransferable = reader.bool();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -149,6 +163,7 @@ export const ClaimRecord = {
       amountClaim: isSet(object.amountClaim) ? Coin.fromJSON(object.amountClaim) : undefined,
       amountVote: isSet(object.amountVote) ? Coin.fromJSON(object.amountVote) : undefined,
       amountDelegate: isSet(object.amountDelegate) ? Coin.fromJSON(object.amountDelegate) : undefined,
+      isTransferable: isSet(object.isTransferable) ? Boolean(object.isTransferable) : false,
     };
   },
 
@@ -162,6 +177,7 @@ export const ClaimRecord = {
       && (obj.amountVote = message.amountVote ? Coin.toJSON(message.amountVote) : undefined);
     message.amountDelegate !== undefined
       && (obj.amountDelegate = message.amountDelegate ? Coin.toJSON(message.amountDelegate) : undefined);
+    message.isTransferable !== undefined && (obj.isTransferable = message.isTransferable);
     return obj;
   },
 
@@ -178,6 +194,7 @@ export const ClaimRecord = {
     message.amountDelegate = (object.amountDelegate !== undefined && object.amountDelegate !== null)
       ? Coin.fromPartial(object.amountDelegate)
       : undefined;
+    message.isTransferable = object.isTransferable ?? false;
     return message;
   },
 };

--- a/ts-client/arkeonetwork.arkeo.claim/types/arkeo/claim/tx.ts
+++ b/ts-client/arkeonetwork.arkeo.claim/types/arkeo/claim/tx.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import _m0 from "protobufjs/minimal";
+import { Chain, chainFromJSON, chainToJSON } from "./claim_record";
 
 export const protobufPackage = "arkeonetwork.arkeo.claim";
 
@@ -27,6 +28,17 @@ export interface MsgTransferClaim {
 }
 
 export interface MsgTransferClaimResponse {
+}
+
+/** this line is used by starport scaffolding # proto/tx/message */
+export interface MsgAddClaim {
+  creator: string;
+  chain: Chain;
+  address: string;
+  amount: number;
+}
+
+export interface MsgAddClaimResponse {
 }
 
 function createBaseMsgClaimEth(): MsgClaimEth {
@@ -318,12 +330,128 @@ export const MsgTransferClaimResponse = {
   },
 };
 
+function createBaseMsgAddClaim(): MsgAddClaim {
+  return { creator: "", chain: 0, address: "", amount: 0 };
+}
+
+export const MsgAddClaim = {
+  encode(message: MsgAddClaim, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.creator !== "") {
+      writer.uint32(10).string(message.creator);
+    }
+    if (message.chain !== 0) {
+      writer.uint32(16).int32(message.chain);
+    }
+    if (message.address !== "") {
+      writer.uint32(26).string(message.address);
+    }
+    if (message.amount !== 0) {
+      writer.uint32(32).int32(message.amount);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgAddClaim {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgAddClaim();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.creator = reader.string();
+          break;
+        case 2:
+          message.chain = reader.int32() as any;
+          break;
+        case 3:
+          message.address = reader.string();
+          break;
+        case 4:
+          message.amount = reader.int32();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgAddClaim {
+    return {
+      creator: isSet(object.creator) ? String(object.creator) : "",
+      chain: isSet(object.chain) ? chainFromJSON(object.chain) : 0,
+      address: isSet(object.address) ? String(object.address) : "",
+      amount: isSet(object.amount) ? Number(object.amount) : 0,
+    };
+  },
+
+  toJSON(message: MsgAddClaim): unknown {
+    const obj: any = {};
+    message.creator !== undefined && (obj.creator = message.creator);
+    message.chain !== undefined && (obj.chain = chainToJSON(message.chain));
+    message.address !== undefined && (obj.address = message.address);
+    message.amount !== undefined && (obj.amount = Math.round(message.amount));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgAddClaim>, I>>(object: I): MsgAddClaim {
+    const message = createBaseMsgAddClaim();
+    message.creator = object.creator ?? "";
+    message.chain = object.chain ?? 0;
+    message.address = object.address ?? "";
+    message.amount = object.amount ?? 0;
+    return message;
+  },
+};
+
+function createBaseMsgAddClaimResponse(): MsgAddClaimResponse {
+  return {};
+}
+
+export const MsgAddClaimResponse = {
+  encode(_: MsgAddClaimResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgAddClaimResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgAddClaimResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgAddClaimResponse {
+    return {};
+  },
+
+  toJSON(_: MsgAddClaimResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgAddClaimResponse>, I>>(_: I): MsgAddClaimResponse {
+    const message = createBaseMsgAddClaimResponse();
+    return message;
+  },
+};
+
 /** Msg defines the Msg service. */
 export interface Msg {
   ClaimEth(request: MsgClaimEth): Promise<MsgClaimEthResponse>;
   ClaimArkeo(request: MsgClaimArkeo): Promise<MsgClaimArkeoResponse>;
-  /** this line is used by starport scaffolding # proto/tx/rpc */
   TransferClaim(request: MsgTransferClaim): Promise<MsgTransferClaimResponse>;
+  /** this line is used by starport scaffolding # proto/tx/rpc */
+  AddClaim(request: MsgAddClaim): Promise<MsgAddClaimResponse>;
 }
 
 export class MsgClientImpl implements Msg {
@@ -333,6 +461,7 @@ export class MsgClientImpl implements Msg {
     this.ClaimEth = this.ClaimEth.bind(this);
     this.ClaimArkeo = this.ClaimArkeo.bind(this);
     this.TransferClaim = this.TransferClaim.bind(this);
+    this.AddClaim = this.AddClaim.bind(this);
   }
   ClaimEth(request: MsgClaimEth): Promise<MsgClaimEthResponse> {
     const data = MsgClaimEth.encode(request).finish();
@@ -350,6 +479,12 @@ export class MsgClientImpl implements Msg {
     const data = MsgTransferClaim.encode(request).finish();
     const promise = this.rpc.request("arkeonetwork.arkeo.claim.Msg", "TransferClaim", data);
     return promise.then((data) => MsgTransferClaimResponse.decode(new _m0.Reader(data)));
+  }
+
+  AddClaim(request: MsgAddClaim): Promise<MsgAddClaimResponse> {
+    const data = MsgAddClaim.encode(request).finish();
+    const promise = this.rpc.request("arkeonetwork.arkeo.claim.Msg", "AddClaim", data);
+    return promise.then((data) => MsgAddClaimResponse.decode(new _m0.Reader(data)));
   }
 }
 

--- a/x/claim/client/cli/tx.go
+++ b/x/claim/client/cli/tx.go
@@ -26,6 +26,7 @@ func GetTxCmd() *cobra.Command {
 	cmd.AddCommand(CmdClaimEth())
 	cmd.AddCommand(CmdClaimArkeo())
 	cmd.AddCommand(CmdTransferClaim())
+	cmd.AddCommand(CmdAddClaim())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/claim/client/cli/tx_add_claim.go
+++ b/x/claim/client/cli/tx_add_claim.go
@@ -4,13 +4,10 @@ package cli
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 )
-
-var _ = strconv.Itoa(0)
 
 func CmdAddClaim() *cobra.Command {
 	cmd := &cobra.Command{

--- a/x/claim/client/cli/tx_add_claim.go
+++ b/x/claim/client/cli/tx_add_claim.go
@@ -1,0 +1,28 @@
+//go:build !testnet
+
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdAddClaim() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-claim [chain] [address] [amount]",
+		Short: "Broadcast message add-claim",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			return fmt.Errorf("add-claim command only available on testnet build")
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/claim/client/cli/tx_add_claim_testnet.go
+++ b/x/claim/client/cli/tx_add_claim_testnet.go
@@ -1,0 +1,55 @@
+//go:build testnet
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+
+	"github.com/arkeonetwork/arkeo/x/claim/types"
+)
+
+func CmdAddClaim() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-claim [chain] [address] [amount]",
+		Short: "Broadcast message add-claim",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			argChain := args[0]
+			chain, err := types.ChainFromString(argChain)
+			if err != nil {
+				return fmt.Errorf("invalid chain(%s),err: %w", argChain, err)
+			}
+			argAddress := args[1]
+			argAmount, err := cast.ToInt64E(args[2])
+			if err != nil {
+				return err
+			}
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgAddClaim(
+				clientCtx.GetFromAddress().String(),
+				chain,
+				argAddress,
+				argAmount,
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/claim/keeper/msg_server_add_claim.go
+++ b/x/claim/keeper/msg_server_add_claim.go
@@ -12,6 +12,6 @@ import (
 
 func (k msgServer) AddClaim(goCtx context.Context, msg *types.MsgAddClaim) (*types.MsgAddClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	_ = ctx
+	ctx.Logger().Info("received add-claim message,not support")
 	return &types.MsgAddClaimResponse{}, nil
 }

--- a/x/claim/keeper/msg_server_add_claim.go
+++ b/x/claim/keeper/msg_server_add_claim.go
@@ -1,0 +1,17 @@
+//go:build !testnet
+
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/arkeonetwork/arkeo/x/claim/types"
+)
+
+func (k msgServer) AddClaim(goCtx context.Context, msg *types.MsgAddClaim) (*types.MsgAddClaimResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	_ = ctx
+	return &types.MsgAddClaimResponse{}, nil
+}

--- a/x/claim/keeper/msg_server_add_claim.go
+++ b/x/claim/keeper/msg_server_add_claim.go
@@ -4,14 +4,11 @@ package keeper
 
 import (
 	"context"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"fmt"
 
 	"github.com/arkeonetwork/arkeo/x/claim/types"
 )
 
 func (k msgServer) AddClaim(goCtx context.Context, msg *types.MsgAddClaim) (*types.MsgAddClaimResponse, error) {
-	ctx := sdk.UnwrapSDKContext(goCtx)
-	ctx.Logger().Info("received add-claim message,not support")
-	return &types.MsgAddClaimResponse{}, nil
+	return nil, fmt.Errorf("MsgAddClaim is only support on testnet.")
 }

--- a/x/claim/keeper/msg_server_add_claim_testnet.go
+++ b/x/claim/keeper/msg_server_add_claim_testnet.go
@@ -1,0 +1,37 @@
+//go:build testnet
+
+package keeper
+
+import (
+	"context"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/arkeonetwork/arkeo/x/claim/types"
+)
+
+func (k msgServer) AddClaim(goCtx context.Context, msg *types.MsgAddClaim) (*types.MsgAddClaimResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	ctx.Logger().Info("receive add-claim request", "chain", msg.Chain.String(),
+		"address", msg.Address,
+		"creator", msg.Creator,
+		"amount", msg.Amount)
+	// This method is only provide on testnet for test purpose , so allow to override the record
+	coin := sdk.NewCoin(types.DefaultClaimDenom, sdk.NewInt(msg.Amount))
+	claim := types.ClaimRecord{
+		Chain:          msg.Chain,
+		Address:        msg.Address,
+		AmountClaim:    coin,
+		AmountVote:     coin,
+		AmountDelegate: coin,
+		IsTransferable: false,
+	}
+	if msg.Chain == types.ARKEO {
+		claim.IsTransferable = true
+	}
+	if err := k.Keeper.SetClaimRecord(ctx, claim); err != nil {
+		return nil, fmt.Errorf("fail to save claim record to db,err: %w", err)
+	}
+	return &types.MsgAddClaimResponse{}, nil
+}

--- a/x/claim/keeper/msg_server_add_claim_testnet_test.go
+++ b/x/claim/keeper/msg_server_add_claim_testnet_test.go
@@ -1,0 +1,48 @@
+//go:build testnet
+
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arkeonetwork/arkeo/testutil/utils"
+	"github.com/arkeonetwork/arkeo/x/claim/types"
+)
+
+func TestAddClaim(t *testing.T) {
+	msgServer, keepers, ctx := setupMsgServer(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	creator := utils.GetRandomArkeoAddress()
+	target := utils.GetRandomArkeoAddress()
+	addClaimMsg := types.NewMsgAddClaim(creator.String(), types.ARKEO, target.String(), 1000_00000000)
+	result, err := msgServer.AddClaim(ctx, addClaimMsg)
+	require.NotNil(t, result)
+	require.Nil(t, err)
+
+	cr, err := keepers.ClaimKeeper.GetClaimRecord(sdkCtx, target.String(), types.ARKEO)
+	require.Nil(t, err)
+	require.False(t, cr.IsEmpty())
+	require.Equal(t, cr.Address, target.String())
+	require.Equal(t, cr.Chain, types.ARKEO)
+	require.Equal(t, cr.IsTransferable, true)
+	require.True(t, cr.AmountClaim.Equal(sdk.NewCoin(types.DefaultClaimDenom, sdk.NewInt(addClaimMsg.Amount))))
+	require.True(t, cr.AmountVote.Equal(sdk.NewCoin(types.DefaultClaimDenom, sdk.NewInt(addClaimMsg.Amount))))
+	require.True(t, cr.AmountDelegate.Equal(sdk.NewCoin(types.DefaultClaimDenom, sdk.NewInt(addClaimMsg.Amount))))
+
+	addClaimMsg = types.NewMsgAddClaim(creator.String(), types.ETHEREUM, utils.GetRandomETHAddress(), 1000_00000000)
+	result, err = msgServer.AddClaim(ctx, addClaimMsg)
+	require.NotNil(t, result)
+	require.Nil(t, err)
+	cr, err = keepers.ClaimKeeper.GetClaimRecord(sdkCtx, target.String(), types.ETHEREUM)
+	require.Nil(t, err)
+	require.False(t, cr.IsEmpty())
+	require.Equal(t, cr.Address, target.String())
+	require.Equal(t, cr.Chain, types.ETHEREUM)
+	require.Equal(t, cr.IsTransferable, false)
+	require.True(t, cr.AmountClaim.Equal(sdk.NewCoin(types.DefaultClaimDenom, sdk.NewInt(addClaimMsg.Amount))))
+	require.True(t, cr.AmountVote.Equal(sdk.NewCoin(types.DefaultClaimDenom, sdk.NewInt(addClaimMsg.Amount))))
+	require.True(t, cr.AmountDelegate.Equal(sdk.NewCoin(types.DefaultClaimDenom, sdk.NewInt(addClaimMsg.Amount))))
+}

--- a/x/claim/module_simulation.go
+++ b/x/claim/module_simulation.go
@@ -38,6 +38,10 @@ const (
 	// TODO: Determine the simulation weight value
 	defaultWeightMsgTransferClaim int = 100
 
+	opWeightMsgAddClaim = "op_weight_msg_add_claim"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgAddClaim int = 100
+
 	// this line is used by starport scaffolding # simapp/module/const
 )
 
@@ -102,6 +106,17 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 	operations = append(operations, simulation.NewWeightedOperation(
 		weightMsgTransferClaim,
 		claimsimulation.SimulateMsgTransferClaim(am.accountKeeper, am.bankKeeper, am.keeper),
+	))
+
+	var weightMsgAddClaim int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgAddClaim, &weightMsgAddClaim, nil,
+		func(_ *rand.Rand) {
+			weightMsgAddClaim = defaultWeightMsgAddClaim
+		},
+	)
+	operations = append(operations, simulation.NewWeightedOperation(
+		weightMsgAddClaim,
+		claimsimulation.SimulateMsgAddClaim(am.accountKeeper, am.bankKeeper, am.keeper),
 	))
 
 	// this line is used by starport scaffolding # simapp/module/operation

--- a/x/claim/simulation/add_claim.go
+++ b/x/claim/simulation/add_claim.go
@@ -1,0 +1,29 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/arkeonetwork/arkeo/x/claim/keeper"
+	"github.com/arkeonetwork/arkeo/x/claim/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+)
+
+func SimulateMsgAddClaim(
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
+	k keeper.Keeper,
+) simtypes.Operation {
+	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		msg := &types.MsgAddClaim{
+			Creator: simAccount.Address.String(),
+		}
+
+		// TODO: Handling the AddClaim simulation
+
+		return simtypes.NoOpMsg(types.ModuleName, msg.Type(), "AddClaim simulation not implemented"), nil, nil
+	}
+}

--- a/x/claim/types/claim_record.go
+++ b/x/claim/types/claim_record.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"fmt"
+	"strings"
+)
+
 func (claimRecord *ClaimRecord) IsEmpty() bool {
 	if *claimRecord == (ClaimRecord{}) {
 		return true
@@ -22,4 +27,14 @@ func (claimRecord *ClaimRecord) IsEmpty() bool {
 	}
 
 	return true
+}
+
+// ChainFromString convert chain string to Chain Enum type
+func ChainFromString(chain string) (Chain, error) {
+	for id, item := range Chain_name {
+		if strings.EqualFold(item, chain) {
+			return Chain(id), nil
+		}
+	}
+	return Chain(-1), fmt.Errorf("invalid chain")
 }

--- a/x/claim/types/claim_record.go
+++ b/x/claim/types/claim_record.go
@@ -31,10 +31,9 @@ func (claimRecord *ClaimRecord) IsEmpty() bool {
 
 // ChainFromString convert chain string to Chain Enum type
 func ChainFromString(chain string) (Chain, error) {
-	for id, item := range Chain_name {
-		if strings.EqualFold(item, chain) {
-			return Chain(id), nil
-		}
+	chainID, ok := Chain_value[strings.ToUpper(chain)]
+	if ok {
+		return Chain(chainID), nil
 	}
 	return Chain(-1), fmt.Errorf("invalid chain")
 }

--- a/x/claim/types/codec.go
+++ b/x/claim/types/codec.go
@@ -11,6 +11,7 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgClaimEth{}, "claim/ClaimEth", nil)
 	cdc.RegisterConcrete(&MsgClaimArkeo{}, "claim/ClaimArkeo", nil)
 	cdc.RegisterConcrete(&MsgTransferClaim{}, "claim/TransferClaim", nil)
+	cdc.RegisterConcrete(&MsgAddClaim{}, "claim/AddClaim", nil)
 	// this line is used by starport scaffolding # 2
 }
 
@@ -23,6 +24,9 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgTransferClaim{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgAddClaim{},
 	)
 	// this line is used by starport scaffolding # 3
 

--- a/x/claim/types/message_add_claim.go
+++ b/x/claim/types/message_add_claim.go
@@ -45,13 +45,12 @@ func (msg *MsgAddClaim) ValidateBasic() error {
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
-	_, err = sdk.AccAddressFromBech32(msg.Address)
-	if err != nil {
-		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid  address (%s)", err)
-	}
 	_, ok := Chain_value[msg.Chain.String()]
 	if !ok {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid chain(%s),err: %s", msg.Chain, err)
+	}
+	if !IsValidAddress(msg.Address, msg.Chain) {
+		return errors.Wrap(sdkerrors.ErrInvalidAddress, "invalid  address")
 	}
 	if msg.Amount <= 0 {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "amount should larger than 0")

--- a/x/claim/types/message_add_claim.go
+++ b/x/claim/types/message_add_claim.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const TypeMsgAddClaim = "add_claim"
+
+var _ sdk.Msg = &MsgAddClaim{}
+
+func NewMsgAddClaim(creator string, chain Chain, address string, amount int64) *MsgAddClaim {
+	return &MsgAddClaim{
+		Creator: creator,
+		Chain:   chain,
+		Address: address,
+		Amount:  amount,
+	}
+}
+
+func (msg *MsgAddClaim) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgAddClaim) Type() string {
+	return TypeMsgAddClaim
+}
+
+func (msg *MsgAddClaim) GetSigners() []sdk.AccAddress {
+	creator, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{creator}
+}
+
+func (msg *MsgAddClaim) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgAddClaim) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+	_, err = sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid  address (%s)", err)
+	}
+	_, ok := Chain_value[msg.Chain.String()]
+	if !ok {
+		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid chain(%s),err: %s", msg.Chain, err)
+	}
+	if msg.Amount <= 0 {
+		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "amount should larger than 0")
+	}
+	return nil
+}

--- a/x/claim/types/message_add_claim_test.go
+++ b/x/claim/types/message_add_claim_test.go
@@ -1,0 +1,78 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arkeonetwork/arkeo/testutil/sample"
+)
+
+func TestMsgAddClaim_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  MsgAddClaim
+		err  error
+	}{
+		{
+			name: "invalid creator address",
+			msg: MsgAddClaim{
+				Creator: "invalid_address",
+				Address: sample.AccAddress(),
+				Chain:   ARKEO,
+				Amount:  100,
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "invalid address",
+			msg: MsgAddClaim{
+				Creator: sample.AccAddress(),
+				Address: "invalid address",
+				Chain:   ARKEO,
+				Amount:  100,
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "invalid chain",
+			msg: MsgAddClaim{
+				Creator: sample.AccAddress(),
+				Address: sample.AccAddress(),
+				Chain:   Chain(100),
+				Amount:  100,
+			},
+			err: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid amount",
+			msg: MsgAddClaim{
+				Creator: sample.AccAddress(),
+				Address: sample.AccAddress(),
+				Chain:   ARKEO,
+				Amount:  -100,
+			},
+			err: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "valid address",
+			msg: MsgAddClaim{
+				Creator: sample.AccAddress(),
+				Address: sample.AccAddress(),
+				Chain:   ARKEO,
+				Amount:  100,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
close #74 
This PR add a new message `add-claim` , which will only available when the binary is build with `--tags testnet`  , so we could broadcast a `MsgAddClaim` message to create a claim record in key value store for test purpose.

This feature will be removed before mainnet launch

There are some format changes on proto files , because I run `make proto-format` command 