### PR TITLE
Fix local mocknet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ".arkeo:/.arkeo:rw"
     environment:
       NET: "testnet"
+    entrypoint: /scripts/genesis.sh
     command: arkeod start --home /.arkeo --pruning nothing
 
   arkeod-1:


### PR DESCRIPTION
I usually run `docker compose up --build -d` locally , this will start up `arkeod` genesis node , and also a validator node in the network .

Recent change in docker-compose.yml break it , so add this back to get it fixed