### PR TITLE
cleans up proto buf formatting and better variable names

### DIFF
--- a/proto/arkeo/arkeo/keeper.proto
+++ b/proto/arkeo/arkeo/keeper.proto
@@ -16,7 +16,7 @@ message Provider {
       [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   int32 chain = 2
       [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.Chain" ];
-  string metadataURI = 3;
+  string metadata_uri = 3;
   uint64 metadata_nonce = 4;
   ProviderStatus status = 5;
   int64 min_contract_duration = 6;

--- a/proto/arkeo/arkeo/tx.proto
+++ b/proto/arkeo/arkeo/tx.proto
@@ -37,13 +37,13 @@ message MsgModProvider {
   string pub_key = 2
       [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   string chain = 3;
-  string metadataURI = 4;
-  uint64 metadataNonce = 5;
+  string metadata_uri = 4;
+  uint64 metadata_nonce = 5;
   ProviderStatus status = 6;
-  int64 minContractDuration = 7;
-  int64 maxContractDuration = 8;
-  int64 subscriptionRate = 9;
-  int64 payAsYouGoRate = 10;
+  int64 min_contract_duration = 7;
+  int64 max_contract_duration = 8;
+  int64 subscription_rate = 9;
+  int64 pay_as_you_go_rate = 10;
 }
 
 message MsgModProviderResponse {}
@@ -57,7 +57,7 @@ message MsgOpenContract {
       [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   string delegate = 5
       [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
-  ContractType cType = 6;
+  ContractType contract_type = 6;
   int64 duration = 7;
   int64 rate = 8;
   string deposit = 9 [

--- a/sentinel/auth.go
+++ b/sentinel/auth.go
@@ -146,13 +146,13 @@ func (p Proxy) freeTier(remoteAddr string) (int, error) {
 	return http.StatusOK, nil
 }
 
-func (p Proxy) isRateLimited(key string, ctype types.ContractType) bool {
+func (p Proxy) isRateLimited(key string, contractType types.ContractType) bool {
 	mu.Lock()
 	defer mu.Unlock()
 
 	var limitTokens int
 	var limitDuration time.Duration
-	switch ctype {
+	switch contractType {
 	case types.ContractType_Subscription:
 		limitTokens = p.Config.SubTierRateLimit
 		limitDuration = p.Config.SubTierRateLimitDuration

--- a/sentinel/events.go
+++ b/sentinel/events.go
@@ -72,7 +72,7 @@ func parseProviderModEvent(input map[string]string) (ProviderModEvent, error) {
 				return evt, err
 			}
 		case "metadata_uri":
-			evt.Provider.MetadataURI = v
+			evt.Provider.MetadataUri = v
 		case "metadata_nonce":
 			evt.Provider.MetadataNonce, err = strconv.ParseUint(v, 10, 64)
 			if err != nil {

--- a/ts-client/arkeo.arkeo/types/arkeo/arkeo/tx.ts
+++ b/ts-client/arkeo.arkeo/types/arkeo/arkeo/tx.ts
@@ -44,7 +44,7 @@ export interface MsgOpenContract {
   chain: string;
   client: string;
   delegate: string;
-  cType: ContractType;
+  contractType: ContractType;
   duration: number;
   rate: number;
   deposit: string;
@@ -373,7 +373,7 @@ export const MsgModProviderResponse = {
 };
 
 function createBaseMsgOpenContract(): MsgOpenContract {
-  return { creator: "", pubKey: "", chain: "", client: "", delegate: "", cType: 0, duration: 0, rate: 0, deposit: "" };
+  return { creator: "", pubKey: "", chain: "", client: "", delegate: "", contractType: 0, duration: 0, rate: 0, deposit: "" };
 }
 
 export const MsgOpenContract = {
@@ -393,8 +393,8 @@ export const MsgOpenContract = {
     if (message.delegate !== "") {
       writer.uint32(42).string(message.delegate);
     }
-    if (message.cType !== 0) {
-      writer.uint32(48).int32(message.cType);
+    if (message.contractType !== 0) {
+      writer.uint32(48).int32(message.contractType);
     }
     if (message.duration !== 0) {
       writer.uint32(56).int64(message.duration);
@@ -431,7 +431,7 @@ export const MsgOpenContract = {
           message.delegate = reader.string();
           break;
         case 6:
-          message.cType = reader.int32() as any;
+          message.contractType = reader.int32() as any;
           break;
         case 7:
           message.duration = longToNumber(reader.int64() as Long);
@@ -457,7 +457,7 @@ export const MsgOpenContract = {
       chain: isSet(object.chain) ? String(object.chain) : "",
       client: isSet(object.client) ? String(object.client) : "",
       delegate: isSet(object.delegate) ? String(object.delegate) : "",
-      cType: isSet(object.cType) ? contractTypeFromJSON(object.cType) : 0,
+      contractType: isSet(object.contractType) ? contractTypeFromJSON(object.contractType) : 0,
       duration: isSet(object.duration) ? Number(object.duration) : 0,
       rate: isSet(object.rate) ? Number(object.rate) : 0,
       deposit: isSet(object.deposit) ? String(object.deposit) : "",
@@ -471,7 +471,7 @@ export const MsgOpenContract = {
     message.chain !== undefined && (obj.chain = message.chain);
     message.client !== undefined && (obj.client = message.client);
     message.delegate !== undefined && (obj.delegate = message.delegate);
-    message.cType !== undefined && (obj.cType = contractTypeToJSON(message.cType));
+    message.contractType !== undefined && (obj.contractType = contractTypeToJSON(message.contractType));
     message.duration !== undefined && (obj.duration = Math.round(message.duration));
     message.rate !== undefined && (obj.rate = Math.round(message.rate));
     message.deposit !== undefined && (obj.deposit = message.deposit);
@@ -485,7 +485,7 @@ export const MsgOpenContract = {
     message.chain = object.chain ?? "";
     message.client = object.client ?? "";
     message.delegate = object.delegate ?? "";
-    message.cType = object.cType ?? 0;
+    message.contractType = object.contractType ?? 0;
     message.duration = object.duration ?? 0;
     message.rate = object.rate ?? 0;
     message.deposit = object.deposit ?? "";

--- a/ts-client/arkeo.arkeo/types/arkeo/tx.ts
+++ b/ts-client/arkeo.arkeo/types/arkeo/tx.ts
@@ -44,7 +44,7 @@ export interface MsgOpenContract {
   chain: string;
   client: string;
   delegate: string;
-  cType: ContractType;
+  contractType: ContractType;
   duration: number;
   rate: number;
   deposit: string;
@@ -373,7 +373,7 @@ export const MsgModProviderResponse = {
 };
 
 function createBaseMsgOpenContract(): MsgOpenContract {
-  return { creator: "", pubKey: "", chain: "", client: "", delegate: "", cType: 0, duration: 0, rate: 0, deposit: "" };
+  return { creator: "", pubKey: "", chain: "", client: "", delegate: "", contractType: 0, duration: 0, rate: 0, deposit: "" };
 }
 
 export const MsgOpenContract = {
@@ -393,8 +393,8 @@ export const MsgOpenContract = {
     if (message.delegate !== "") {
       writer.uint32(42).string(message.delegate);
     }
-    if (message.cType !== 0) {
-      writer.uint32(48).int32(message.cType);
+    if (message.contractType !== 0) {
+      writer.uint32(48).int32(message.contractType);
     }
     if (message.duration !== 0) {
       writer.uint32(56).int64(message.duration);
@@ -431,7 +431,7 @@ export const MsgOpenContract = {
           message.delegate = reader.string();
           break;
         case 6:
-          message.cType = reader.int32() as any;
+          message.contractType = reader.int32() as any;
           break;
         case 7:
           message.duration = longToNumber(reader.int64() as Long);
@@ -457,7 +457,7 @@ export const MsgOpenContract = {
       chain: isSet(object.chain) ? String(object.chain) : "",
       client: isSet(object.client) ? String(object.client) : "",
       delegate: isSet(object.delegate) ? String(object.delegate) : "",
-      cType: isSet(object.cType) ? contractTypeFromJSON(object.cType) : 0,
+      contractType: isSet(object.contractType) ? contractTypeFromJSON(object.contractType) : 0,
       duration: isSet(object.duration) ? Number(object.duration) : 0,
       rate: isSet(object.rate) ? Number(object.rate) : 0,
       deposit: isSet(object.deposit) ? String(object.deposit) : "",
@@ -471,7 +471,7 @@ export const MsgOpenContract = {
     message.chain !== undefined && (obj.chain = message.chain);
     message.client !== undefined && (obj.client = message.client);
     message.delegate !== undefined && (obj.delegate = message.delegate);
-    message.cType !== undefined && (obj.cType = contractTypeToJSON(message.cType));
+    message.contractType !== undefined && (obj.contractType = contractTypeToJSON(message.contractType));
     message.duration !== undefined && (obj.duration = Math.round(message.duration));
     message.rate !== undefined && (obj.rate = Math.round(message.rate));
     message.deposit !== undefined && (obj.deposit = message.deposit);
@@ -485,7 +485,7 @@ export const MsgOpenContract = {
     message.chain = object.chain ?? "";
     message.client = object.client ?? "";
     message.delegate = object.delegate ?? "";
-    message.cType = object.cType ?? 0;
+    message.contractType = object.contractType ?? 0;
     message.duration = object.duration ?? 0;
     message.rate = object.rate ?? 0;
     message.deposit = object.deposit ?? "";

--- a/ts-client/arkeo.arkeo/types/google/protobuf/descriptor.ts
+++ b/ts-client/arkeo.arkeo/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/arkeonetwork.arkeo.claim/types/google/protobuf/descriptor.ts
+++ b/ts-client/arkeonetwork.arkeo.claim/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.auth.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.auth.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.authz.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.authz.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.bank.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.bank.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.base.tendermint.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.base.tendermint.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.crisis.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.crisis.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.distribution.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.distribution.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.evidence.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.evidence.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.feegrant.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.feegrant.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.gov.v1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.gov.v1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.gov.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.gov.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.group.v1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.group.v1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.mint.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.mint.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.nft.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.nft.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.params.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.params.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.slashing.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.slashing.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.staking.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.staking.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.tx.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.tx.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.upgrade.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.upgrade.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/cosmos.vesting.v1beta1/types/google/protobuf/descriptor.ts
+++ b/ts-client/cosmos.vesting.v1beta1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/ibc.applications.interchain_accounts.controller.v1/types/google/protobuf/descriptor.ts
+++ b/ts-client/ibc.applications.interchain_accounts.controller.v1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/ibc.applications.interchain_accounts.host.v1/types/google/protobuf/descriptor.ts
+++ b/ts-client/ibc.applications.interchain_accounts.host.v1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/ibc.applications.transfer.v1/types/google/protobuf/descriptor.ts
+++ b/ts-client/ibc.applications.transfer.v1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/ibc.core.channel.v1/types/google/protobuf/descriptor.ts
+++ b/ts-client/ibc.core.channel.v1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/ibc.core.client.v1/types/google/protobuf/descriptor.ts
+++ b/ts-client/ibc.core.client.v1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/ibc.core.connection.v1/types/google/protobuf/descriptor.ts
+++ b/ts-client/ibc.core.connection.v1/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/mercury.mercury/types/google/protobuf/descriptor.ts
+++ b/ts-client/mercury.mercury/types/google/protobuf/descriptor.ts
@@ -664,7 +664,7 @@ export interface FieldOptions {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  ctype: FieldOptions_CType;
+  ctype: FieldOptions_ContractType;
   /**
    * The packed option can be enabled for repeated primitive fields to enable
    * a more efficient representation on the wire. Rather than repeatedly
@@ -730,7 +730,7 @@ export interface FieldOptions {
   uninterpretedOption: UninterpretedOption[];
 }
 
-export enum FieldOptions_CType {
+export enum FieldOptions_ContractType {
   /** STRING - Default mode. */
   STRING = 0,
   CORD = 1,
@@ -738,33 +738,33 @@ export enum FieldOptions_CType {
   UNRECOGNIZED = -1,
 }
 
-export function fieldOptions_CTypeFromJSON(object: any): FieldOptions_CType {
+export function fieldOptions_ContractTypeFromJSON(object: any): FieldOptions_ContractType {
   switch (object) {
     case 0:
     case "STRING":
-      return FieldOptions_CType.STRING;
+      return FieldOptions_ContractType.STRING;
     case 1:
     case "CORD":
-      return FieldOptions_CType.CORD;
+      return FieldOptions_ContractType.CORD;
     case 2:
     case "STRING_PIECE":
-      return FieldOptions_CType.STRING_PIECE;
+      return FieldOptions_ContractType.STRING_PIECE;
     case -1:
     case "UNRECOGNIZED":
     default:
-      return FieldOptions_CType.UNRECOGNIZED;
+      return FieldOptions_ContractType.UNRECOGNIZED;
   }
 }
 
-export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
+export function fieldOptions_ContractTypeToJSON(object: FieldOptions_ContractType): string {
   switch (object) {
-    case FieldOptions_CType.STRING:
+    case FieldOptions_ContractType.STRING:
       return "STRING";
-    case FieldOptions_CType.CORD:
+    case FieldOptions_ContractType.CORD:
       return "CORD";
-    case FieldOptions_CType.STRING_PIECE:
+    case FieldOptions_ContractType.STRING_PIECE:
       return "STRING_PIECE";
-    case FieldOptions_CType.UNRECOGNIZED:
+    case FieldOptions_ContractType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
   }
@@ -2816,7 +2816,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
-      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      ctype: isSet(object.ctype) ? fieldOptions_ContractTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
       lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
@@ -2830,7 +2830,7 @@ export const FieldOptions = {
 
   toJSON(message: FieldOptions): unknown {
     const obj: any = {};
-    message.ctype !== undefined && (obj.ctype = fieldOptions_CTypeToJSON(message.ctype));
+    message.ctype !== undefined && (obj.ctype = fieldOptions_ContractTypeToJSON(message.ctype));
     message.packed !== undefined && (obj.packed = message.packed);
     message.jstype !== undefined && (obj.jstype = fieldOptions_JSTypeToJSON(message.jstype));
     message.lazy !== undefined && (obj.lazy = message.lazy);

--- a/ts-client/mercury.mercury/types/mercury/tx.ts
+++ b/ts-client/mercury.mercury/types/mercury/tx.ts
@@ -44,7 +44,7 @@ export interface MsgOpenContract {
   chain: string;
   client: string;
   delegate: string;
-  cType: ContractType;
+  contractType: ContractType;
   duration: number;
   rate: number;
   deposit: string;
@@ -373,7 +373,7 @@ export const MsgModProviderResponse = {
 };
 
 function createBaseMsgOpenContract(): MsgOpenContract {
-  return { creator: "", pubKey: "", chain: "", client: "", delegate: "", cType: 0, duration: 0, rate: 0, deposit: "" };
+  return { creator: "", pubKey: "", chain: "", client: "", delegate: "", contractType: 0, duration: 0, rate: 0, deposit: "" };
 }
 
 export const MsgOpenContract = {
@@ -393,8 +393,8 @@ export const MsgOpenContract = {
     if (message.delegate !== "") {
       writer.uint32(42).string(message.delegate);
     }
-    if (message.cType !== 0) {
-      writer.uint32(48).int32(message.cType);
+    if (message.contractType !== 0) {
+      writer.uint32(48).int32(message.contractType);
     }
     if (message.duration !== 0) {
       writer.uint32(56).int64(message.duration);
@@ -431,7 +431,7 @@ export const MsgOpenContract = {
           message.delegate = reader.string();
           break;
         case 6:
-          message.cType = reader.int32() as any;
+          message.contractType = reader.int32() as any;
           break;
         case 7:
           message.duration = longToNumber(reader.int64() as Long);
@@ -457,7 +457,7 @@ export const MsgOpenContract = {
       chain: isSet(object.chain) ? String(object.chain) : "",
       client: isSet(object.client) ? String(object.client) : "",
       delegate: isSet(object.delegate) ? String(object.delegate) : "",
-      cType: isSet(object.cType) ? contractTypeFromJSON(object.cType) : 0,
+      contractType: isSet(object.contractType) ? contractTypeFromJSON(object.contractType) : 0,
       duration: isSet(object.duration) ? Number(object.duration) : 0,
       rate: isSet(object.rate) ? Number(object.rate) : 0,
       deposit: isSet(object.deposit) ? String(object.deposit) : "",
@@ -471,7 +471,7 @@ export const MsgOpenContract = {
     message.chain !== undefined && (obj.chain = message.chain);
     message.client !== undefined && (obj.client = message.client);
     message.delegate !== undefined && (obj.delegate = message.delegate);
-    message.cType !== undefined && (obj.cType = contractTypeToJSON(message.cType));
+    message.contractType !== undefined && (obj.contractType = contractTypeToJSON(message.contractType));
     message.duration !== undefined && (obj.duration = Math.round(message.duration));
     message.rate !== undefined && (obj.rate = Math.round(message.rate));
     message.deposit !== undefined && (obj.deposit = message.deposit);
@@ -485,7 +485,7 @@ export const MsgOpenContract = {
     message.chain = object.chain ?? "";
     message.client = object.client ?? "";
     message.delegate = object.delegate ?? "";
-    message.cType = object.cType ?? 0;
+    message.contractType = object.contractType ?? 0;
     message.duration = object.duration ?? 0;
     message.rate = object.rate ?? 0;
     message.deposit = object.deposit ?? "";

--- a/x/arkeo/client/cli/tx_open_contract.go
+++ b/x/arkeo/client/cli/tx_open_contract.go
@@ -35,7 +35,7 @@ func CmdOpenContract() *cobra.Command {
 				return err
 			}
 
-			argCType, err := cast.ToInt32E(args[3])
+			argContractType, err := cast.ToInt32E(args[3])
 			if err != nil {
 				return err
 			}
@@ -72,7 +72,7 @@ func CmdOpenContract() *cobra.Command {
 				argChain,
 				cl,
 				delegate,
-				types.ContractType(argCType),
+				types.ContractType(argContractType),
 				argDuration,
 				argRate,
 				deposit,

--- a/x/arkeo/keeper/events.go
+++ b/x/arkeo/keeper/events.go
@@ -44,7 +44,7 @@ func (k msgServer) ModProviderEvent(ctx cosmos.Context, provider types.Provider)
 				types.EventTypeProviderMod,
 				sdk.NewAttribute("pubkey", provider.PubKey.String()),
 				sdk.NewAttribute("chain", provider.Chain.String()),
-				sdk.NewAttribute("metadata_uri", provider.MetadataURI),
+				sdk.NewAttribute("metadata_uri", provider.MetadataUri),
 				sdk.NewAttribute("metadata_nonce", strconv.FormatUint(provider.MetadataNonce, 10)),
 				sdk.NewAttribute("status", provider.Status.String()),
 				sdk.NewAttribute("min_contract_duration", strconv.FormatInt(provider.MinContractDuration, 10)),

--- a/x/arkeo/keeper/msg_server_mod_provider.go
+++ b/x/arkeo/keeper/msg_server_mod_provider.go
@@ -19,7 +19,7 @@ func (k msgServer) ModProvider(goCtx context.Context, msg *types.MsgModProvider)
 		"receive MsgModProvider",
 		"pubkey", msg.PubKey,
 		"chain", msg.Chain,
-		"metatadata uri", msg.MetadataURI,
+		"metatadata uri", msg.MetadataUri,
 		"metadata nonce", msg.MetadataNonce,
 		"status", msg.Status,
 		"min contract duration", msg.MinContractDuration,
@@ -84,8 +84,8 @@ func (k msgServer) ModProviderHandle(ctx cosmos.Context, msg *types.MsgModProvid
 	}
 
 	// update metadata URI
-	if len(msg.MetadataURI) > 0 {
-		provider.MetadataURI = msg.MetadataURI
+	if len(msg.MetadataUri) > 0 {
+		provider.MetadataUri = msg.MetadataUri
 	}
 
 	// update metadata nonce

--- a/x/arkeo/keeper/msg_server_mod_provider_test.go
+++ b/x/arkeo/keeper/msg_server_mod_provider_test.go
@@ -61,7 +61,7 @@ func (ModProviderSuite) TestHandle(c *C) {
 		Creator:             acct.String(),
 		PubKey:              pubkey,
 		Chain:               common.BTCChain.String(),
-		MetadataURI:         "foobar",
+		MetadataUri:         "foobar",
 		MetadataNonce:       3,
 		MinContractDuration: 10,
 		MaxContractDuration: 500,
@@ -73,7 +73,7 @@ func (ModProviderSuite) TestHandle(c *C) {
 
 	provider, err := k.GetProvider(ctx, msg.PubKey, common.BTCChain)
 	c.Assert(err, IsNil)
-	c.Check(provider.MetadataURI, Equals, "foobar")
+	c.Check(provider.MetadataUri, Equals, "foobar")
 	c.Check(provider.MetadataNonce, Equals, uint64(3))
 	c.Check(provider.MinContractDuration, Equals, int64(10))
 	c.Check(provider.MaxContractDuration, Equals, int64(500))

--- a/x/arkeo/keeper/msg_server_open_contract.go
+++ b/x/arkeo/keeper/msg_server_open_contract.go
@@ -21,7 +21,7 @@ func (k msgServer) OpenContract(goCtx context.Context, msg *types.MsgOpenContrac
 		"chain", msg.Chain,
 		"client", msg.Client,
 		"delegate", msg.Delegate,
-		"contract type", msg.CType,
+		"contract type", msg.ContractType,
 		"duration", msg.Duration,
 		"rate", msg.Rate,
 	)
@@ -72,7 +72,7 @@ func (k msgServer) OpenContractValidate(ctx cosmos.Context, msg *types.MsgOpenCo
 		return errors.Wrapf(types.ErrOpenContractDuration, "duration below allowed minimum duration from provider")
 	}
 
-	switch msg.CType {
+	switch msg.ContractType {
 	case types.ContractType_Subscription:
 		if msg.Rate != provider.SubscriptionRate {
 			return errors.Wrapf(types.ErrOpenContractMismatchRate, "provider rates is %d, client sent %d", provider.SubscriptionRate, msg.Rate)
@@ -85,7 +85,7 @@ func (k msgServer) OpenContractValidate(ctx cosmos.Context, msg *types.MsgOpenCo
 			return errors.Wrapf(types.ErrOpenContractMismatchRate, "pay-as-you-go provider rate is %d, client sent %d", provider.PayAsYouGoRate, msg.Rate)
 		}
 	default:
-		return errors.Wrapf(types.ErrInvalidContractType, "%s", msg.CType.String())
+		return errors.Wrapf(types.ErrInvalidContractType, "%s", msg.ContractType.String())
 	}
 
 	contract, err := k.GetContract(ctx, msg.PubKey, chain, msg.FetchSpender())
@@ -118,7 +118,7 @@ func (k msgServer) OpenContractHandle(ctx cosmos.Context, msg *types.MsgOpenCont
 	}
 	contract := types.NewContract(msg.PubKey, chain, msg.FetchSpender())
 	contract.Client = msg.Client
-	contract.Type = msg.CType
+	contract.Type = msg.ContractType
 	contract.Height = ctx.BlockHeight()
 	contract.Duration = msg.Duration
 	contract.Rate = msg.Rate

--- a/x/arkeo/keeper/msg_server_open_contract_test.go
+++ b/x/arkeo/keeper/msg_server_open_contract_test.go
@@ -35,14 +35,14 @@ func (OpenContractSuite) TestValidate(c *C) {
 
 	// happy path
 	msg := types.MsgOpenContract{
-		PubKey:   pubkey,
-		Chain:    chain.String(),
-		Client:   acc,
-		Creator:  acc.String(),
-		CType:    types.ContractType_Subscription,
-		Duration: 100,
-		Rate:     15,
-		Deposit:  cosmos.NewInt(100 * 15),
+		PubKey:       pubkey,
+		Chain:        chain.String(),
+		Client:       acc,
+		Creator:      acc.String(),
+		ContractType: types.ContractType_Subscription,
+		Duration:     100,
+		Rate:         15,
+		Deposit:      cosmos.NewInt(100 * 15),
 	}
 	c.Assert(s.OpenContractValidate(ctx, &msg), IsNil)
 
@@ -59,11 +59,11 @@ func (OpenContractSuite) TestValidate(c *C) {
 	msg.Rate = 10
 	err = s.OpenContractValidate(ctx, &msg)
 	c.Check(err, ErrIs, types.ErrOpenContractMismatchRate)
-	msg.CType = types.ContractType_PayAsYouGo
+	msg.ContractType = types.ContractType_PayAsYouGo
 	err = s.OpenContractValidate(ctx, &msg)
 	c.Check(err, ErrIs, types.ErrOpenContractMismatchRate)
 	msg.Rate = 15
-	msg.CType = types.ContractType_Subscription
+	msg.ContractType = types.ContractType_Subscription
 
 	provider.Bond = cosmos.NewInt(1)
 	c.Assert(k.SetProvider(ctx, provider), IsNil)
@@ -96,14 +96,14 @@ func (OpenContractSuite) TestHandle(c *C) {
 	c.Assert(k.MintAndSendToAccount(ctx, acc, getCoin(common.Tokens(10))), IsNil)
 
 	msg := types.MsgOpenContract{
-		PubKey:   pubkey,
-		Chain:    chain.String(),
-		Creator:  acc.String(),
-		Client:   pubkey,
-		CType:    types.ContractType_PayAsYouGo,
-		Duration: 100,
-		Rate:     15,
-		Deposit:  cosmos.NewInt(1000),
+		PubKey:       pubkey,
+		Chain:        chain.String(),
+		Creator:      acc.String(),
+		Client:       pubkey,
+		ContractType: types.ContractType_PayAsYouGo,
+		Duration:     100,
+		Rate:         15,
+		Deposit:      cosmos.NewInt(1000),
 	}
 	c.Assert(s.OpenContractHandle(ctx, &msg), IsNil)
 

--- a/x/arkeo/types/message_mod_provider.go
+++ b/x/arkeo/types/message_mod_provider.go
@@ -13,12 +13,12 @@ const TypeMsgModProvider = "mod_provider"
 
 var _ sdk.Msg = &MsgModProvider{}
 
-func NewMsgModProvider(creator string, pubkey common.PubKey, chain, metadataURI string, metadataNonce uint64, status ProviderStatus, minContractDuration, maxContractDuration, subscriptionRate, payAsYouGoRate int64) *MsgModProvider {
+func NewMsgModProvider(creator string, pubkey common.PubKey, chain, metadataUri string, metadataNonce uint64, status ProviderStatus, minContractDuration, maxContractDuration, subscriptionRate, payAsYouGoRate int64) *MsgModProvider {
 	return &MsgModProvider{
 		Creator:             creator,
 		PubKey:              pubkey,
 		Chain:               chain,
-		MetadataURI:         metadataURI,
+		MetadataUri:         metadataUri,
 		MetadataNonce:       metadataNonce,
 		Status:              status,
 		MinContractDuration: minContractDuration,
@@ -92,8 +92,8 @@ func (msg *MsgModProvider) ValidateBasic() error {
 		}
 	*/
 	// Ensure URIs don't get too long and cause chain bloat
-	if len(msg.MetadataURI) > 100 {
-		return errors.Wrapf(ErrInvalidModProviderMetdataURI, "length is too long (%d/100)", len(msg.MetadataURI))
+	if len(msg.MetadataUri) > 100 {
+		return errors.Wrapf(ErrInvalidModProviderMetdataURI, "length is too long (%d/100)", len(msg.MetadataUri))
 	}
 
 	// check durations

--- a/x/arkeo/types/message_mod_provider_test.go
+++ b/x/arkeo/types/message_mod_provider_test.go
@@ -32,13 +32,13 @@ func (MsgModProviderSuite) TestValidateBasic(c *C) {
 		Chain:               common.BTCChain.String(),
 		MinContractDuration: 12,
 		MaxContractDuration: 30,
-		MetadataURI:         "http://mad.hatter.net/test?foo=baz",
+		MetadataUri:         "http://mad.hatter.net/test?foo=baz",
 	}
 	err = msg.ValidateBasic()
 	c.Assert(err, IsNil)
 
 	// URI is too long
-	msg.MetadataURI = "http://mad.hatter.net/testsdkfjlsdkfjlsdfjsldfjkdsljflsdjfkdsjflsdjkfsdjlfsdjkfldsjflksjdfljsdlkfjsdlkfjdsklfjsdlkfjsdkljflksdjfklsdjflskdjflksdjflksdjfldsjflksdjfldskjflsdkfjsdlkjfksdljflskdjfsdlkjfdksljflsdkjfkldsjfsdlkfjlksdjfklsdjflkdsjfklsdjfsdkljflksdjflksdfjdklsjfl?foo=baz"
+	msg.MetadataUri = "http://mad.hatter.net/testsdkfjlsdkfjlsdfjsldfjkdsljflsdjfkdsjflsdjkfsdjlfsdjkfldsjflksjdfljsdlkfjsdlkfjdsklfjsdlkfjsdkljflksdjfklsdjflskdjflksdjflksdjfldsjflksdjfldskjflsdkfjsdlkjfksdljflskdjfsdlkjfdksljflsdkjfkldsjfsdlkfjlksdjfklsdjflkdsjfklsdjfsdkljflksdjflksdfjdklsjfl?foo=baz"
 	err = msg.ValidateBasic()
 	c.Check(err, ErrIs, ErrInvalidModProviderMetdataURI)
 }

--- a/x/arkeo/types/message_open_contract.go
+++ b/x/arkeo/types/message_open_contract.go
@@ -14,17 +14,17 @@ const TypeMsgOpenContract = "open_contract"
 
 var _ sdk.Msg = &MsgOpenContract{}
 
-func NewMsgOpenContract(creator string, pubkey common.PubKey, chain string, client, delegate common.PubKey, cType ContractType, duration, rate int64, deposit cosmos.Int) *MsgOpenContract {
+func NewMsgOpenContract(creator string, pubkey common.PubKey, chain string, client, delegate common.PubKey, contractType ContractType, duration, rate int64, deposit cosmos.Int) *MsgOpenContract {
 	return &MsgOpenContract{
-		Creator:  creator,
-		PubKey:   pubkey,
-		Chain:    chain,
-		CType:    cType,
-		Duration: duration,
-		Rate:     rate,
-		Client:   client,
-		Deposit:  deposit,
-		Delegate: delegate,
+		Creator:      creator,
+		PubKey:       pubkey,
+		Chain:        chain,
+		ContractType: contractType,
+		Duration:     duration,
+		Rate:         rate,
+		Client:       client,
+		Deposit:      deposit,
+		Delegate:     delegate,
 	}
 }
 


### PR DESCRIPTION
- renames cType to contractType
- modifies proto files to expected formatting `lower_case`
closed #88 