### PR TITLE
use tarkeo address prefix for testnet

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -118,8 +118,7 @@ import (
 )
 
 const (
-	AccountAddressPrefix = "arkeo"
-	Name                 = "arkeo"
+	Name = "arkeo"
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals

--- a/app/app_mainnet.go
+++ b/app/app_mainnet.go
@@ -1,0 +1,7 @@
+//go:build !testnet
+
+package app
+
+const (
+	AccountAddressPrefix = "arkeo"
+)

--- a/app/app_testnet.go
+++ b/app/app_testnet.go
@@ -1,0 +1,7 @@
+//go:build testnet
+
+package app
+
+const (
+	AccountAddressPrefix = "tarkeo"
+)


### PR DESCRIPTION
Fix #82  , this PR to use `tarkeo` as address prefix for testnet , and `arkeo` address prefix only for mainnet.

for chain-id , it will be set only on genesis