### PR TITLE
changes the reserve account name to avoid collisions

### DIFF
--- a/x/arkeo/types/keys.go
+++ b/x/arkeo/types/keys.go
@@ -3,7 +3,7 @@ package types
 const (
 	// ModuleName defines the module name
 	ModuleName   = "arkeo"
-	ReserveName  = "reserve"
+	ReserveName  = "arkeo-reserve"
 	ProviderName = "providers"
 	ContractName = "contracts"
 


### PR DESCRIPTION
using `ignite chain serve` creates issues with the reserve module account arkeo uses.

You can see this by doing the following 

`ignite chain serve`
`curl -X GET "http://0.0.0.0:1317/cosmos/auth/v1beta1/module_accounts/reserve" -H  "accept: application/json"`
compare the output vs 
`curl -X GET "http://0.0.0.0:1317/cosmos/auth/v1beta1/module_accounts/providers" -H  "accept: application/json"`

Now if you pull down this PR and attempt
`curl -X GET "http://0.0.0.0:1317/cosmos/auth/v1beta1/module_accounts/arko-reserve" -H  "accept: application/json"`

You will see this is resolved.  This fixes issues with attempting to open contracts and a host of other panic errors when using ignite locally. 
