### PR TITLE
extended cli poc

### DIFF
--- a/arkeocli/arkeocli.go
+++ b/arkeocli/arkeocli.go
@@ -1,0 +1,23 @@
+package arkeocli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+)
+
+var (
+	arkeoCmd = &cobra.Command{
+		Use:   "arkeo",
+		Short: "arkeo subcommands",
+	}
+)
+
+func GetArkeoCmd() *cobra.Command {
+	flags.AddTxFlagsToCmd(bondProviderCmd)
+	bondProviderCmd.Flags().StringP("pubkey", "p", "", "provider pubkey")
+	bondProviderCmd.Flags().StringP("chain", "c", "", "provider chain")
+	bondProviderCmd.Flags().String("bond", "", "provider bond amount")
+	arkeoCmd.AddCommand(bondProviderCmd)
+
+	return arkeoCmd
+}

--- a/arkeocli/arkeocli.go
+++ b/arkeocli/arkeocli.go
@@ -1,23 +1,14 @@
 package arkeocli
 
 import (
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 )
 
-var (
-	arkeoCmd = &cobra.Command{
+func GetArkeoCmd() *cobra.Command {
+	arkeoCmd := &cobra.Command{
 		Use:   "arkeo",
 		Short: "arkeo subcommands",
 	}
-)
-
-func GetArkeoCmd() *cobra.Command {
-	flags.AddTxFlagsToCmd(bondProviderCmd)
-	bondProviderCmd.Flags().StringP("pubkey", "p", "", "provider pubkey")
-	bondProviderCmd.Flags().StringP("chain", "c", "", "provider chain")
-	bondProviderCmd.Flags().String("bond", "", "provider bond amount")
-	arkeoCmd.AddCommand(bondProviderCmd)
-
+	arkeoCmd.AddCommand(newBondProviderCmd())
 	return arkeoCmd
 }

--- a/arkeocli/bond.go
+++ b/arkeocli/bond.go
@@ -7,18 +7,25 @@ import (
 	"github.com/arkeonetwork/arkeo/common/cosmos"
 	"github.com/arkeonetwork/arkeo/x/arkeo/types"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/spf13/cobra"
 )
 
-var (
-	bondProviderCmd = &cobra.Command{
+func newBondProviderCmd() *cobra.Command {
+	bondProviderCmd := &cobra.Command{
 		Use:   "bond-provider",
 		Short: "bond or modify provider bond",
 		Args:  cobra.ExactArgs(0),
 		RunE:  runBondProviderCmd,
 	}
-)
+
+	flags.AddTxFlagsToCmd(bondProviderCmd)
+	bondProviderCmd.Flags().StringP("pubkey", "p", "", "provider pubkey")
+	bondProviderCmd.Flags().StringP("chain", "c", "", "provider chain")
+	bondProviderCmd.Flags().String("bond", "", "provider bond amount")
+	return bondProviderCmd
+}
 
 func runBondProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	clientCtx, err := client.GetClientTxContext(cmd)

--- a/arkeocli/bond.go
+++ b/arkeocli/bond.go
@@ -1,0 +1,120 @@
+package arkeocli
+
+import (
+	"fmt"
+
+	"github.com/arkeonetwork/arkeo/common"
+	"github.com/arkeonetwork/arkeo/common/cosmos"
+	"github.com/arkeonetwork/arkeo/x/arkeo/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bondProviderCmd = &cobra.Command{
+		Use:   "bond-provider",
+		Short: "bond or modify provider bond",
+		Args:  cobra.ExactArgs(0),
+		RunE:  runBondProviderCmd,
+	}
+)
+
+func runBondProviderCmd(cmd *cobra.Command, args []string) (err error) {
+	clientCtx, err := client.GetClientTxContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	fromAddr := clientCtx.GetFromAddress().String()
+	if fromAddr == "" {
+		readFrom, err := promptForArg(cmd, "Specify from key or address: ")
+		if err != nil {
+			return err
+		}
+
+		// readFrom := "alice"
+		// readFrom := "tarkeo1up3pwhguqvr7l7pr8t53nmjrlxx03x0y0axw9z"
+
+		var accAddr cosmos.AccAddress
+		key, err := clientCtx.Keyring.Key(readFrom)
+		if err != nil {
+			accAddr, err = cosmos.AccAddressFromBech32(readFrom)
+			if err != nil {
+				return err
+			}
+			key, err = clientCtx.Keyring.KeyByAddress(accAddr)
+			if err != nil {
+				return err
+			}
+		}
+		accAddr, err = key.GetAddress()
+		if err != nil {
+			return err
+		}
+
+		clientCtx = clientCtx.WithFromName(key.Name).WithFromAddress(accAddr)
+		if err = client.SetCmdClientContext(cmd, clientCtx); err != nil {
+			return err
+		}
+	}
+
+	argPubkey, _ := cmd.Flags().GetString("pubkey")
+	if argPubkey == "" {
+		argPubkey, err = promptForArg(cmd, "Specify provider pubkey: ")
+		if err != nil {
+			return err
+		}
+	}
+
+	argChain, _ := cmd.Flags().GetString("chain")
+	if argChain == "" {
+		argChain, err = promptForArg(cmd, "Specify chain (e.g. gaia-mainnet-rpc-archive, btc-mainnet-fullnode, etc): ")
+		if err != nil {
+			return err
+		}
+	}
+
+	// ensure valid chain
+	_, err = common.NewChain(argChain)
+	if err != nil {
+		return
+	}
+
+	argBond, _ := cmd.Flags().GetString("bond")
+	if argBond == "" {
+		argBond, err = promptForArg(cmd, "Specify bond amount (e.g. 100uarkeo): ")
+		if err != nil {
+			return err
+		}
+	}
+
+	coins, err := cosmos.ParseCoins(argBond)
+	if err != nil {
+		return err
+	}
+	if len(coins) != 1 {
+		return fmt.Errorf("1 coins as bond amount, got %d", len(coins))
+	}
+	if coins[0].Denom != "uarkeo" {
+		return fmt.Errorf("bad bond denom, expected \"uarkeo\" got \"%s\"", coins[0].Denom)
+	}
+	if coins[0].Amount.IsNegative() || coins[0].Amount.IsZero() {
+		return fmt.Errorf("bad bond amount: %s", argBond)
+	}
+
+	pubkey, err := common.NewPubKey(argPubkey)
+	if err != nil {
+		return err
+	}
+	msg := types.NewMsgBondProvider(
+		clientCtx.GetFromAddress().String(),
+		pubkey,
+		argChain,
+		coins[0].Amount,
+	)
+	if err := msg.ValidateBasic(); err != nil {
+		return err
+	}
+	return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+}

--- a/arkeocli/bond.go
+++ b/arkeocli/bond.go
@@ -79,12 +79,6 @@ func runBondProviderCmd(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	// ensure valid chain
-	_, err = common.NewChain(argChain)
-	if err != nil {
-		return
-	}
-
 	argBond, _ := cmd.Flags().GetString("bond")
 	if argBond == "" {
 		argBond, err = promptForArg(cmd, "Specify bond amount (e.g. 100uarkeo, negative to unbond): ")

--- a/arkeocli/bond.go
+++ b/arkeocli/bond.go
@@ -40,9 +40,6 @@ func runBondProviderCmd(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 
-		// readFrom := "alice"
-		// readFrom := "tarkeo1up3pwhguqvr7l7pr8t53nmjrlxx03x0y0axw9z"
-
 		var accAddr cosmos.AccAddress
 		key, err := clientCtx.Keyring.Key(readFrom)
 		if err != nil {

--- a/arkeocli/bond_test.go
+++ b/arkeocli/bond_test.go
@@ -1,0 +1,46 @@
+package arkeocli
+
+import (
+	"testing"
+
+	"github.com/arkeonetwork/arkeo/common/cosmos"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBondAmount(t *testing.T) {
+	amount, err := parseBondAmount("100uarkeo")
+	require.NoError(t, err)
+	require.Equal(t, cosmos.NewInt(100), amount)
+
+	amount, err = parseBondAmount("-100uarkeo")
+	require.NoError(t, err)
+	require.Equal(t, cosmos.NewInt(-100), amount)
+
+	_, err = parseBondAmount("100arkeo")
+	require.ErrorContains(t, err, "bad bond denom")
+
+	_, err = parseBondAmount("-100arkeo")
+	require.ErrorContains(t, err, "bad bond denom")
+
+	_, err = parseBondAmount("100")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "bad bond denom")
+
+	_, err = parseBondAmount("-100")
+	require.ErrorContains(t, err, "bad bond denom")
+
+	_, err = parseBondAmount("")
+	require.ErrorContains(t, err, "bad bond denom")
+
+	_, err = parseBondAmount("uarkeo")
+	require.ErrorContains(t, err, "bad bond amount")
+
+	_, err = parseBondAmount("uarkeo")
+	require.ErrorContains(t, err, "bad bond amount")
+
+	_, err = parseBondAmount("Paul Revere")
+	require.ErrorContains(t, err, "bad bond denom")
+
+	_, err = parseBondAmount("100uarkeo 100uarkeo")
+	require.ErrorContains(t, err, "bad bond denom")
+}

--- a/arkeocli/utils.go
+++ b/arkeocli/utils.go
@@ -1,0 +1,19 @@
+package arkeocli
+
+import (
+	"bufio"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func promptForArg(cmd *cobra.Command, prompt string) (string, error) {
+	cmd.Print(prompt)
+	reader := bufio.NewReader(cmd.InOrStdin())
+	read, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	read = strings.TrimSpace(read)
+	return read, nil
+}

--- a/cmd/arkeod/main.go
+++ b/cmd/arkeod/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/arkeonetwork/arkeo/app"
+	"github.com/arkeonetwork/arkeo/arkeocli"
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	"github.com/ignite/cli/ignite/pkg/cosmoscmd"
@@ -23,6 +24,8 @@ func main() {
 		app.New,
 		// this line is used by starport scaffolding # root/arguments
 	)
+	// add in arkeo specific utilities
+	rootCmd.AddCommand(arkeocli.GetArkeoCmd())
 	if err := svrcmd.Execute(rootCmd, "", app.DefaultNodeHome); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
poc supports bond provider via flags/interactive:
```
arkeod arkeo bond-provider                                           
Specify from key or address: adam
Specify provider pubkey: tarkeopub1addwnpepq2tjwwcpqwswatymx7uw3q75sqhljmp0qw3pz2fvnavkv7k2jvknqk25q7j
Specify chain (e.g. gaia-mainnet-rpc-archive, btc-mainnet-fullnode, etc): gaia-mainnet-rpc-archive
Specify bond amount (e.g. 100uarkeo): 456uarkeo
auth_info:
  fee:
    amount: []
    ...
txhash: 3BD522DD672AD8C0E06B7C6BE20DC2ABDC849D2AB52322C98C8718E400DF4DE7
```