### PR TITLE
mod-provider

### DIFF
--- a/arkeocli/arkeocli.go
+++ b/arkeocli/arkeocli.go
@@ -10,5 +10,6 @@ func GetArkeoCmd() *cobra.Command {
 		Short: "arkeo subcommands",
 	}
 	arkeoCmd.AddCommand(newBondProviderCmd())
+	arkeoCmd.AddCommand(newModProviderCmd())
 	return arkeoCmd
 }

--- a/arkeocli/bond.go
+++ b/arkeocli/bond.go
@@ -21,9 +21,9 @@ func newBondProviderCmd() *cobra.Command {
 	}
 
 	flags.AddTxFlagsToCmd(bondProviderCmd)
-	bondProviderCmd.Flags().StringP("pubkey", "p", "", "provider pubkey")
-	bondProviderCmd.Flags().StringP("chain", "c", "", "provider chain")
-	bondProviderCmd.Flags().String("bond", "", "provider bond amount")
+	bondProviderCmd.Flags().String("pubkey", "", "provider pubkey")
+	bondProviderCmd.Flags().String("service", "", "provider service name")
+	bondProviderCmd.Flags().String("bond", "", "provider bond amount (negative to unbond)")
 	return bondProviderCmd
 }
 
@@ -33,47 +33,30 @@ func runBondProviderCmd(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	fromAddr := clientCtx.GetFromAddress().String()
-	if fromAddr == "" {
-		readFrom, err := promptForArg(cmd, "Specify from key or address: ")
-		if err != nil {
-			return err
-		}
-
-		var accAddr cosmos.AccAddress
-		key, err := clientCtx.Keyring.Key(readFrom)
-		if err != nil {
-			accAddr, err = cosmos.AccAddressFromBech32(readFrom)
-			if err != nil {
-				return err
-			}
-			key, err = clientCtx.Keyring.KeyByAddress(accAddr)
-			if err != nil {
-				return err
-			}
-		}
-		accAddr, err = key.GetAddress()
-		if err != nil {
-			return err
-		}
-
-		clientCtx = clientCtx.WithFromName(key.Name).WithFromAddress(accAddr)
-		if err = client.SetCmdClientContext(cmd, clientCtx); err != nil {
-			return err
-		}
+	key, err := ensureKeys(cmd)
+	if err != nil {
+		return err
+	}
+	addr, err := key.GetAddress()
+	if err != nil {
+		return
+	}
+	clientCtx = clientCtx.WithFromName(key.Name).WithFromAddress(addr)
+	if err = client.SetCmdClientContext(cmd, clientCtx); err != nil {
+		return
 	}
 
 	argPubkey, _ := cmd.Flags().GetString("pubkey")
 	if argPubkey == "" {
-		argPubkey, err = promptForArg(cmd, "Specify provider pubkey: ")
+		argPubkey, err = toPubkey(cmd, addr)
 		if err != nil {
-			return err
+			return
 		}
 	}
 
-	argChain, _ := cmd.Flags().GetString("chain")
-	if argChain == "" {
-		argChain, err = promptForArg(cmd, "Specify chain (e.g. gaia-mainnet-rpc-archive, btc-mainnet-fullnode, etc): ")
+	argService, _ := cmd.Flags().GetString("service")
+	if argService == "" {
+		argService, err = promptForArg(cmd, "Specify service (e.g. gaia-mainnet-rpc-archive, btc-mainnet-fullnode, etc): ")
 		if err != nil {
 			return err
 		}
@@ -98,7 +81,7 @@ func runBondProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	msg := types.NewMsgBondProvider(
 		clientCtx.GetFromAddress().String(),
 		pubkey,
-		argChain,
+		argService,
 		bond,
 	)
 	if err := msg.ValidateBasic(); err != nil {

--- a/arkeocli/mod.go
+++ b/arkeocli/mod.go
@@ -1,0 +1,184 @@
+package arkeocli
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/arkeonetwork/arkeo/common"
+	"github.com/arkeonetwork/arkeo/x/arkeo/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cobra"
+)
+
+func newModProviderCmd() *cobra.Command {
+	modProviderCmd := &cobra.Command{
+		Use:   "mod-provider",
+		Short: "mod provider",
+		Args:  cobra.ExactArgs(0),
+		RunE:  runModProviderCmd,
+	}
+
+	flags.AddTxFlagsToCmd(modProviderCmd)
+	modProviderCmd.Flags().String("pubkey", "", "provider pubkey")
+	modProviderCmd.Flags().String("service", "", "provider service name")
+	modProviderCmd.Flags().String("status", "", "provider status (online or offline)")
+	modProviderCmd.Flags().String("meta-uri", "", "public endpoint where metadata can be found")
+	modProviderCmd.Flags().Uint64("meta-nonce", 0, "increment with each metadata change")
+	modProviderCmd.Flags().Uint64("min-duration", 0, "minimum contract duration (in blocks)")
+	modProviderCmd.Flags().Uint64("max-duration", 0, "maximum contract duration (in blocks)")
+	modProviderCmd.Flags().Uint64("settlement-duration", 0, "settlement duration (in blocks)")
+	modProviderCmd.Flags().Uint64("subscription-rate", 0, "rate for subscription contracts")
+	modProviderCmd.Flags().Uint64("pay-as-you-go-rate", 0, "rate for pay-as-you-go contracts")
+	return modProviderCmd
+}
+
+func runModProviderCmd(cmd *cobra.Command, args []string) (err error) {
+	clientCtx, err := client.GetClientTxContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	key, err := ensureKeys(cmd)
+	if err != nil {
+		return
+	}
+	addr, err := key.GetAddress()
+	if err != nil {
+		return
+	}
+	clientCtx = clientCtx.WithFromName(key.Name).WithFromAddress(addr)
+	if err = client.SetCmdClientContext(cmd, clientCtx); err != nil {
+		return
+	}
+
+	argPubkey, _ := cmd.Flags().GetString("pubkey")
+	if argPubkey == "" {
+		argPubkey, err = toPubkey(cmd, addr)
+		if err != nil {
+			return
+		}
+	}
+
+	argService, _ := cmd.Flags().GetString("service")
+	if argService == "" {
+		argService, err = promptForArg(cmd, "Specify service (e.g. gaia-mainnet-rpc-archive, btc-mainnet-fullnode, etc): ")
+		if err != nil {
+			return err
+		}
+	}
+
+	argStatus, _ := cmd.Flags().GetString("status")
+	if argStatus == "" {
+		argStatus, err = promptForArg(cmd, "Specify status (one of online or offline): ")
+		if err != nil {
+			return err
+		}
+	}
+
+	argMetaURI, _ := cmd.Flags().GetString("meta-uri")
+	if argMetaURI == "" {
+		argMetaURI, err = promptForArg(cmd, "Specify public endpoint where metadata can be found: ")
+		if err != nil {
+			return err
+		}
+	}
+
+	argMetaNonce, _ := cmd.Flags().GetUint64("meta-nonce")
+	if argMetaNonce == 0 {
+		nonce, err := promptForArg(cmd, "Increment nonce to signal provider metadata changed: ")
+		if err != nil {
+			return err
+		}
+		argMetaNonce, err = strconv.ParseUint(nonce, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	argMinDuration, _ := cmd.Flags().GetUint64("min-duration")
+	if argMinDuration == 0 {
+		duration, err := promptForArg(cmd, "Specify minimum contract duration (in blocks): ")
+		if err != nil {
+			return err
+		}
+		argMinDuration, err = strconv.ParseUint(duration, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	argMaxDuration, _ := cmd.Flags().GetUint64("max-duration")
+	if argMaxDuration == 0 {
+		duration, err := promptForArg(cmd, "Specify maximum contract duration (in blocks): ")
+		if err != nil {
+			return err
+		}
+		argMaxDuration, err = strconv.ParseUint(duration, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	argSettlementDuration, _ := cmd.Flags().GetUint64("settlement-duration")
+	if argSettlementDuration == 0 {
+		duration, err := promptForArg(cmd, "Specify settlement duration (in blocks): ")
+		if err != nil {
+			return err
+		}
+		argSettlementDuration, err = strconv.ParseUint(duration, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	argSubscriptionRate, _ := cmd.Flags().GetUint64("subscription-rate")
+	if argSubscriptionRate == 0 {
+		subscriptiomRate, err := promptForArg(cmd, "Specify rate for subscription contracts: ")
+		if err != nil {
+			return err
+		}
+		argSubscriptionRate, err = strconv.ParseUint(subscriptiomRate, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	argPayAsYouGoRate, _ := cmd.Flags().GetUint64("pay-as-you-go-rate")
+	if argPayAsYouGoRate == 0 {
+		payAsYouGoRate, err := promptForArg(cmd, "Specify rate for pay-as-you-go contracts: ")
+		if err != nil {
+			return err
+		}
+		argPayAsYouGoRate, err = strconv.ParseUint(payAsYouGoRate, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	pubkey, err := common.NewPubKey(argPubkey)
+	if err != nil {
+		return err
+	}
+
+	status := types.ProviderStatus(types.ProviderStatus_value[strings.ToUpper(argStatus)])
+
+	msg := types.NewMsgModProvider(
+		clientCtx.GetFromAddress().String(),
+		pubkey,
+		argService,
+		argMetaURI,
+		argMetaNonce,
+		status,
+		int64(argMinDuration),
+		int64(argMaxDuration),
+		int64(argSubscriptionRate),
+		int64(argPayAsYouGoRate),
+		int64(argSettlementDuration),
+	)
+	if err := msg.ValidateBasic(); err != nil {
+		return err
+	}
+	return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+}

--- a/arkeocli/utils.go
+++ b/arkeocli/utils.go
@@ -2,8 +2,15 @@ package arkeocli
 
 import (
 	"bufio"
+	"fmt"
 	"strings"
 
+	"github.com/arkeonetwork/arkeo/app"
+	"github.com/arkeonetwork/arkeo/common/cosmos"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
 	"github.com/spf13/cobra"
 )
 
@@ -16,4 +23,67 @@ func promptForArg(cmd *cobra.Command, prompt string) (string, error) {
 	}
 	read = strings.TrimSpace(read)
 	return read, nil
+}
+
+func toPubkey(cmd *cobra.Command, addr cosmos.AccAddress) (pubkey string, err error) {
+	clientCtx, err := client.GetClientTxContext(cmd)
+	if err != nil {
+		return
+	}
+	key, err := clientCtx.Keyring.KeyByAddress(addr)
+	if err != nil {
+		return
+	}
+	pub, err := key.GetPubKey()
+	if err != nil {
+		return
+	}
+	pubkey, err = bech32.ConvertAndEncode(getAcctPubPrefix(), legacy.Cdc.MustMarshal(pub))
+	if err != nil {
+		return
+	}
+
+	return pubkey, nil
+}
+
+func getAcctPubPrefix() string {
+	prefix := fmt.Sprintf("%spub", app.AccountAddressPrefix)
+	return prefix
+}
+
+func ensureKeys(cmd *cobra.Command) (key *keyring.Record, err error) {
+	clientCtx, err := client.GetClientTxContext(cmd)
+	if err != nil {
+		return
+	}
+	fromKeyName := clientCtx.GetFromName()
+	fromAddr := clientCtx.GetFromAddress()
+	if fromKeyName != "" && !fromAddr.Empty() {
+		key, err = clientCtx.Keyring.Key(fromKeyName)
+		if err != nil {
+			return
+		}
+		return key, nil
+	}
+
+	readFrom, err := promptForArg(cmd, "Specify from key or address: ")
+	if err != nil {
+		return
+	}
+
+	// try as key id
+	key, err = clientCtx.Keyring.Key(readFrom)
+	if err != nil {
+		// try as bech32 address
+		fromAddr, err = cosmos.AccAddressFromBech32(readFrom)
+		if err != nil {
+			return
+		}
+		key, err = clientCtx.Keyring.KeyByAddress(fromAddr)
+		if err != nil {
+			return
+		}
+	}
+
+	return
 }


### PR DESCRIPTION
implements mod-provider arkeo cli
refactor to infer provider pubkey from key for bond/mod if not specified

```
arkeod arkeo mod-provider
Specify from key or address: adam
Specify service (e.g. gaia-mainnet-rpc-archive, btc-mainnet-fullnode, etc): gaia-mainnet-rpc-archive
Specify status (one of online or offline): online
Specify public endpoint where metadata can be found: http://x.y.z
Increment nonce to signal provider metadata changed: 1
Specify minimum contract duration (in blocks): 10
Specify maximum contract duration (in blocks): 100
Specify settlement duration (in blocks): 10
Specify rate for subscription contracts: 5
Specify rate for pay-as-you-go contracts: 10
auth_info:
  fee:
    amount: []
    gas_limit: "200000"
    granter: ""
    payer: ""
  signer_infos: []
  tip: null
body:
  extension_options: []
  memo: ""
  messages:
  - '@type': /arkeo.arkeo.MsgModProvider
    creator: tarkeo14q4qnm4tmkm9xuhjwu0vw0f8xy7ztexek44nw3
    max_contract_duration: "100"
    metadata_nonce: "1"
    metadata_uri: http://x.y.z
    min_contract_duration: "10"
    pay_as_you_go_rate: "10"
    provider: tarkeopub1addwnpepq2tjwwcpqwswatymx7uw3q75sqhljmp0qw3pz2fvnavkv7k2jvknqk25q7j
    service: gaia-mainnet-rpc-archive
    settlement_duration: "10"
    status: ONLINE
    subscription_rate: "5"
  non_critical_extension_options: []
  timeout_height: "0"
signatures: []
confirm transaction before signing and broadcasting [y/N]: y
...
txhash: 990942591132C6161D0612A6CF99284DC454927E1F43DCB5976E517BB84C6AA2
```