### PR TITLE
Remove spender from claims

### DIFF
--- a/proto/arkeo/arkeo/tx.proto
+++ b/proto/arkeo/arkeo/tx.proto
@@ -81,8 +81,6 @@ message MsgCloseContractResponse {}
 message MsgClaimContractIncome {
   string creator = 1;
   uint64 contract_id = 2;
-  string spender = 3
-      [ (gogoproto.casttype) = "github.com/arkeonetwork/arkeo/common.PubKey" ];
   bytes signature = 4;
   int64 nonce = 5;
 }

--- a/sentinel/auth_test.go
+++ b/sentinel/auth_test.go
@@ -50,12 +50,12 @@ func TestArkAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	// happy path
-	raw := GenerateArkAuthString(contractId, pk, nonce, signature)
+	raw := GenerateArkAuthString(contractId, nonce, signature)
 	_, err = parseArkAuth(raw)
 	require.NoError(t, err)
 
 	// bad signature
-	raw = GenerateArkAuthString(contractId, pk, nonce, signature)
+	raw = GenerateArkAuthString(contractId, nonce, signature)
 	_, err = parseArkAuth(raw + "randome not hex!")
 	require.Error(t, err)
 }

--- a/test/regression/cmd/operations.go
+++ b/test/regression/cmd/operations.go
@@ -15,7 +15,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/arkeonetwork/arkeo/common"
 	"github.com/arkeonetwork/arkeo/sentinel"
 	arkeo "github.com/arkeonetwork/arkeo/x/arkeo/types"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -192,9 +191,6 @@ func createAuth(input map[string]string) (string, bool, error) {
 	if len(input["id"]) == 0 {
 		return "", true, fmt.Errorf("missing required field: id")
 	}
-	if len(input["spender"]) == 0 {
-		return "", true, fmt.Errorf("missing required field: spender")
-	}
 	if len(input["nonce"]) == 0 {
 		return "", true, fmt.Errorf("missing required field: nonce")
 	}
@@ -202,10 +198,6 @@ func createAuth(input map[string]string) (string, bool, error) {
 	id, err := strconv.ParseUint(input["id"], 10, 64)
 	if err != nil {
 		return "", true, fmt.Errorf("failed to parse id: %s", err)
-	}
-	spender, err := common.NewPubKey(input["spender"])
-	if err != nil {
-		return "", true, fmt.Errorf("failed to parse spender pubkey: %s", err)
 	}
 	nonce, err := strconv.ParseInt(input["nonce"], 10, 64)
 	if err != nil {
@@ -236,12 +228,12 @@ func createAuth(input map[string]string) (string, bool, error) {
 	privKey := hd.Secp256k1.Generate()(derivedPriv)
 
 	// sign our msg
-	msg := sentinel.GenerateMessageToSign(id, spender.String(), nonce)
+	msg := sentinel.GenerateMessageToSign(id, nonce)
 	sig, err := privKey.Sign([]byte(msg))
 	if err != nil {
 		return "", true, fmt.Errorf("failed to sign message: %s", err)
 	}
-	arkauth := sentinel.GenerateArkAuthString(id, spender, nonce, sig)
+	arkauth := sentinel.GenerateArkAuthString(id, nonce, sig)
 
 	return arkauth, true, nil
 }

--- a/test/regression/suites/contracts/pay-as-you-go.yaml
+++ b/test/regression/suites/contracts/pay-as-you-go.yaml
@@ -52,7 +52,6 @@ endpoint: http://localhost:3636/swapi.dev/api/people/1
 arkauth:
   signer: cat
   id: "0"
-  spender: {{ pubkey_cat }}
   nonce: "1"
 headers:
   Tier: "paid"
@@ -81,7 +80,7 @@ description: ensure contract shows up in active contracts
 endpoint: http://localhost:3636/open-claims
 asserts:
   - length == 1
-  - .[0].signature == "44a8ca110a13f596e449a95a41e512850c0eed53f08aeb965d12a53a5966c5f148b0502f2600b1aa8ef04376b0f72ede2e09f4e88ea39b0fa7d33e883d6cb6eb"
+  - .[0].signature == "df75d819c52f4ab5f1cf85f3e51388ad42cf5f8e3c9ed5678eb8401c3b90e1ef4f7dc699e742a5fc4f6284e36c44408d657bb81ab1f2ddada25c74d79e07457a"
   - .[0].claimed == false
 ---
 ########################################################################################
@@ -91,7 +90,7 @@ type: check
 description: ensure contract shows up in active contracts
 endpoint: http://localhost:3636/claim/0
 asserts:
-  - .signature == "44a8ca110a13f596e449a95a41e512850c0eed53f08aeb965d12a53a5966c5f148b0502f2600b1aa8ef04376b0f72ede2e09f4e88ea39b0fa7d33e883d6cb6eb"
+  - .signature == "df75d819c52f4ab5f1cf85f3e51388ad42cf5f8e3c9ed5678eb8401c3b90e1ef4f7dc699e742a5fc4f6284e36c44408d657bb81ab1f2ddada25c74d79e07457a"
   - .claimed == false
   - .contract_id == 0
 ---
@@ -102,12 +101,10 @@ type: tx-claim-contract
 signer: {{ addr_fox }}
 creator: {{ addr_fox }}
 contractId: 0
-spender: {{ pubkey_cat }}
 nonce: 1
 arkauth:
   signer: cat
   id: "0"
-  spender: {{ pubkey_cat }}
   nonce: "1"
 ---
 type: create-blocks
@@ -144,12 +141,10 @@ type: tx-claim-contract
 signer: {{ addr_fox }}
 creator: {{ addr_fox }}
 contractId: 0
-spender: {{ pubkey_cat }}
 nonce: 1
 arkauth:
   signer: cat
   id: "0"
-  spender: {{ pubkey_cat }}
   nonce: "1"
 ---
 type: create-blocks

--- a/tools/curleo/main.go
+++ b/tools/curleo/main.go
@@ -72,10 +72,10 @@ func main() {
 	spender := curl.getSpender(*user)
 	contract := curl.getActiveContract(metadata.Configuration.ProviderPubKey.String(), service, spender)
 	if contract.Height == 0 {
-		println(fmt.Sprintf("no active contract found for spender:%s provider:%s cbhain:%s - will attempt free tier", spender, metadata.Configuration.ProviderPubKey.String(), service))
+		println(fmt.Sprintf("no active contract found for provider:%s cbhain:%s - will attempt free tier", metadata.Configuration.ProviderPubKey.String(), service))
 	} else {
 		claim := curl.getClaim(contract.Id)
-		auth := curl.sign(*user, contract.Id, spender, claim.Nonce+1)
+		auth := curl.sign(*user, contract.Id, claim.Nonce+1)
 		values.Add(sentinel.QueryArkAuth, auth)
 	}
 	u.RawQuery = values.Encode()
@@ -187,7 +187,7 @@ func (c Curl) parseMetadata() sentinel.Metadata {
 	return meta
 }
 
-func (c Curl) sign(user string, contractId uint64, spender string, nonce int64) string {
+func (c Curl) sign(user string, contractId uint64, nonce int64) string {
 	interfaceRegistry := codectypes.NewInterfaceRegistry()
 	std.RegisterInterfaces(interfaceRegistry)
 	ModuleBasics.RegisterInterfaces(interfaceRegistry)
@@ -201,7 +201,7 @@ func (c Curl) sign(user string, contractId uint64, spender string, nonce int64) 
 	if err != nil {
 		log.Fatal(err)
 	}
-	msg := sentinel.GenerateMessageToSign(contractId, spender, nonce)
+	msg := sentinel.GenerateMessageToSign(contractId, nonce)
 
 	println("invoking Sign...")
 	signature, pk, err := kb.Sign(user, []byte(msg))

--- a/x/arkeo/client/cli/tx_claim_contract_income.go
+++ b/x/arkeo/client/cli/tx_claim_contract_income.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/hex"
 
-	"github.com/arkeonetwork/arkeo/common"
 	"github.com/arkeonetwork/arkeo/x/arkeo/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -15,7 +14,7 @@ import (
 
 func CmdClaimContractIncome() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "claim-contract-income [contract-id] [spender] [nonce] [signature]",
+		Use:   "claim-contract-income [contract-id] [nonce] [signature]",
 		Short: "Broadcast message claimContractIncome",
 		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -28,23 +27,18 @@ func CmdClaimContractIncome() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			spender, err := common.NewPubKey(args[1])
-			if err != nil {
-				return err
-			}
 
-			argNonce, err := cast.ToInt64E(args[2])
+			argNonce, err := cast.ToInt64E(args[1])
 			if err != nil {
 				return err
 			}
-			signature, err := hex.DecodeString(args[3])
+			signature, err := hex.DecodeString(args[2])
 			if err != nil {
 				return err
 			}
 			msg := types.NewMsgClaimContractIncome(
 				clientCtx.GetFromAddress().String(),
 				argContractId,
-				spender,
 				argNonce,
 				signature,
 			)

--- a/x/arkeo/keeper/msg_server_claim_contract_income.go
+++ b/x/arkeo/keeper/msg_server_claim_contract_income.go
@@ -53,6 +53,14 @@ func (k msgServer) ClaimContractIncomeValidate(ctx cosmos.Context, msg *types.Ms
 		return errors.Wrapf(types.ErrClaimContractIncomeClosed, "settled on block: %d", contract.SettlementPeriodEnd())
 	}
 
+	pk, err := cosmos.GetPubKeyFromBech32(cosmos.Bech32PubKeyTypeAccPub, contract.GetSpender().String())
+	if err != nil {
+		return err
+	}
+	if !pk.VerifySignature(msg.GetBytesToSign(), msg.Signature) {
+		return errors.Wrap(types.ErrClaimContractIncomeInvalidSignature, "")
+	}
+
 	return nil
 }
 

--- a/x/arkeo/keeper/msg_server_open_contract_test.go
+++ b/x/arkeo/keeper/msg_server_open_contract_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/arkeonetwork/arkeo/common/cosmos"
 	"github.com/arkeonetwork/arkeo/x/arkeo/configs"
 	"github.com/arkeonetwork/arkeo/x/arkeo/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	cKeys "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/std"
+	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/stretchr/testify/require"
 )
 
@@ -251,7 +257,19 @@ func TestOpenContractWithSettlementPeriod(t *testing.T) {
 
 	require.NoError(t, err)
 
-	clientPubKey := types.GetRandomPubKey()
+	interfaceRegistry := codectypes.NewInterfaceRegistry()
+	std.RegisterInterfaces(interfaceRegistry)
+	module.NewBasicManager().RegisterInterfaces(interfaceRegistry)
+	types.RegisterInterfaces(interfaceRegistry)
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+
+	kb := cKeys.NewInMemory(cdc)
+	info, _, err := kb.NewMnemonic("whatever", cKeys.English, `m/44'/931'/0'/0/0`, "", hd.Secp256k1)
+	require.NoError(t, err)
+	pk, err := info.GetPubKey()
+	require.NoError(t, err)
+	clientPubKey, err := common.NewPubKeyFromCrypto(pk)
+	require.NoError(t, err)
 	clientAddress, err := clientPubKey.GetMyAddress()
 	require.NoError(t, err)
 	require.NoError(t, k.MintAndSendToAccount(ctx, clientAddress, getCoin(common.Tokens(10))))
@@ -302,6 +320,9 @@ func TestOpenContractWithSettlementPeriod(t *testing.T) {
 		Spender:    clientPubKey,
 		Nonce:      20,
 	}
+	message := claimMsg.GetBytesToSign()
+	claimMsg.Signature, _, err = kb.Sign("whatever", message)
+	require.NoError(t, err)
 	_, err = s.ClaimContractIncome(ctx, &claimMsg)
 	require.NoError(t, err)
 

--- a/x/arkeo/keeper/msg_server_open_contract_test.go
+++ b/x/arkeo/keeper/msg_server_open_contract_test.go
@@ -317,7 +317,6 @@ func TestOpenContractWithSettlementPeriod(t *testing.T) {
 	claimMsg := types.MsgClaimContractIncome{
 		ContractId: contract.Id,
 		Creator:    clientAddress.String(),
-		Spender:    clientPubKey,
 		Nonce:      20,
 	}
 	message := claimMsg.GetBytesToSign()

--- a/x/arkeo/types/message_claim_contract_income_test.go
+++ b/x/arkeo/types/message_claim_contract_income_test.go
@@ -58,11 +58,6 @@ func TestClaimContractIncomeValidateBasic(t *testing.T) {
 	require.NoError(t, err)
 	err = msg.ValidateBasic()
 	require.NoError(t, err)
-
-	// check bad client
-	msg.Spender = common.PubKey("bogus")
-	err = msg.ValidateBasic()
-	require.ErrorIs(t, err, sdkerrors.ErrInvalidPubKey)
 }
 
 func TestValidateSignature(t *testing.T) {

--- a/x/arkeo/types/message_claim_contract_income_test.go
+++ b/x/arkeo/types/message_claim_contract_income_test.go
@@ -32,11 +32,7 @@ func TestClaimContractIncomeValidateBasic(t *testing.T) {
 	acct, err := pubkey.GetMyAddress()
 	require.NoError(t, err)
 	kb := cKeys.NewInMemory(cdc)
-	info, _, err := kb.NewMnemonic("whatever", cKeys.English, `m/44'/931'/0'/0/0`, "", hd.Secp256k1)
-	require.NoError(t, err)
-	pub, err := info.GetPubKey()
-	require.NoError(t, err)
-	spenderPubKey, err := common.NewPubKeyFromCrypto(pub)
+	_, _, err = kb.NewMnemonic("whatever", cKeys.English, `m/44'/931'/0'/0/0`, "", hd.Secp256k1)
 	require.NoError(t, err)
 
 	// invalid address
@@ -50,7 +46,6 @@ func TestClaimContractIncomeValidateBasic(t *testing.T) {
 		Creator:    acct.String(),
 		ContractId: 1,
 		Nonce:      24,
-		Spender:    spenderPubKey,
 	}
 
 	message := msg.GetBytesToSign()
@@ -75,7 +70,6 @@ func TestValidateSignature(t *testing.T) {
 
 	msg := MsgClaimContractIncome{
 		Creator:    acct.String(),
-		Spender:    pubkey,
 		Nonce:      48,
 		ContractId: 500,
 	}
@@ -88,7 +82,7 @@ func TestValidateSignature(t *testing.T) {
 	_, _, err = kb.NewMnemonic("whatever", cKeys.English, `m/44'/931'/0'/0/0`, "", hd.Secp256k1)
 	require.NoError(t, err)
 
-	message := []byte(fmt.Sprintf("%d:%s:%d", msg.ContractId, msg.Spender, msg.Nonce))
+	message := []byte(fmt.Sprintf("%d:%d", msg.ContractId, msg.Nonce))
 	msg.Signature, pub, err = kb.Sign("whatever", message)
 	require.NoError(t, err)
 


### PR DESCRIPTION
The spender pubkey is a "vestigial tail" of sorts and is not needed.