### PR TITLE
allow affiliates with contracts

### DIFF
--- a/arkeocli/open_contract.go
+++ b/arkeocli/open_contract.go
@@ -91,6 +91,23 @@ func runOpenContractCmd(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	var argAffiliate string
+	var affiliate cosmos.AccAddress
+	argNoAffiliate, _ := cmd.Flags().GetBool("no-affiliate")
+	if !argNoAffiliate {
+		argAffiliate, _ = cmd.Flags().GetString("affiliate-address")
+		if argAffiliate == "" {
+			argAffiliate, err = promptForArg(cmd, "Specify affiliate address (leave blank to use no affiliate): ")
+			if err != nil {
+				return err
+			}
+			affiliate, err = cosmos.AccAddressFromBech32(argAffiliate)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	argContractType, _ := cmd.Flags().GetString("contract-type")
 	if argContractType == "" {
 		argContractType, err = promptForArg(cmd, "Specify contract type (subscription or pay-as-you-go): ")
@@ -168,6 +185,7 @@ func runOpenContractCmd(cmd *cobra.Command, args []string) (err error) {
 		argSettlementDuration,
 		rate,
 		deposit,
+		affiliate,
 	)
 	if err := msg.ValidateBasic(); err != nil {
 		return err

--- a/proto/arkeo/arkeo/keeper.proto
+++ b/proto/arkeo/arkeo/keeper.proto
@@ -65,6 +65,7 @@ message Contract {
   int64 settlement_height = 12;
   uint64 id = 13;
   int64 settlement_duration = 14;
+  bytes affiliate = 15  [(gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.AccAddress"];
 }
 
 message ContractSet { repeated uint64 contract_ids = 1 [ packed = true ]; }

--- a/proto/arkeo/arkeo/misc.proto
+++ b/proto/arkeo/arkeo/misc.proto
@@ -9,6 +9,8 @@ message ProtoInt64 { int64 value = 1; }
 
 message ProtoUint64 { uint64 value = 1; }
 
+message ProtoAccAddress { bytes value = 1 [ (gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.AccAddress" ]; }
+
 message ProtoAccAddresses {
   repeated bytes value = 1
       [ (gogoproto.casttype) =

--- a/proto/arkeo/arkeo/tx.proto
+++ b/proto/arkeo/arkeo/tx.proto
@@ -68,6 +68,7 @@ message MsgOpenContract {
     (gogoproto.nullable) = false
   ];
   int64 settlement_duration = 10;
+  bytes affiliate = 11  [(gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.AccAddress"];
 }
 
 message MsgOpenContractResponse {}

--- a/test/regression/mnt/exports/suites_contracts_pay-as-you-go.json
+++ b/test/regression/mnt/exports/suites_contracts_pay-as-you-go.json
@@ -14,6 +14,7 @@
       ],
       "contracts": [
         {
+          "affiliate": "",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "100",

--- a/test/regression/mnt/exports/suites_contracts_subscription.json
+++ b/test/regression/mnt/exports/suites_contracts_subscription.json
@@ -22,6 +22,7 @@
       ],
       "contracts": [
         {
+          "affiliate": "",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "100",
@@ -41,6 +42,7 @@
           "type": "SUBSCRIPTION"
         },
         {
+          "affiliate": "",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "100",

--- a/x/arkeo/client/cli/tx_open_contract.go
+++ b/x/arkeo/client/cli/tx_open_contract.go
@@ -16,7 +16,7 @@ import (
 
 func CmdOpenContract() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "open-contract [provider_pubkey] [service] [client_pubkey] [c-type] [deposit] [duration] [rate] [settlement-duration] [delegation-optional]",
+		Use:   "open-contract [provider_pubkey] [service] [client_pubkey] [c-type] [deposit] [duration] [rate] [settlement-duration] [delegation-optional] [affiliate-optional]",
 		Short: "Broadcast message openContract",
 		Args:  cobra.ExactArgs(8),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -67,6 +67,14 @@ func CmdOpenContract() *cobra.Command {
 				}
 			}
 
+			affiliate := cosmos.AccAddress{}
+			if len(args) > 9 {
+				affiliate, err = cosmos.AccAddressFromBech32(args[9])
+				if err != nil {
+					return err
+				}
+			}
+
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
@@ -83,6 +91,7 @@ func CmdOpenContract() *cobra.Command {
 				argSettlementDuration,
 				argRate,
 				deposit,
+				affiliate,
 			)
 			if err := msg.ValidateBasic(); err != nil {
 				return err

--- a/x/arkeo/configs/config_v1.go
+++ b/x/arkeo/configs/config_v1.go
@@ -15,6 +15,7 @@ func NewConfigValue010() *ConfigVals {
 			OpenContractCost:           common.Tokens(1), // cost to open a contract
 			MinProviderBond:            common.Tokens(1), // min bond for a data provider to be able to open contracts with
 			ReserveTax:                 1000,             // reserve income off provider income, in basis points
+			AffilateFee:                5000,             // affiliate fee (in basis points) determines how much of tax collected goes to reserve vs affiliate
 			BlocksPerYear:              5256666,          // blocks per year
 			EmissionCurve:              4,                // rate in which the reserve is depleted to pay validators
 			ValidatorPayoutCycle:       1,                // how often validators are paid out rewards

--- a/x/arkeo/configs/config_values.go
+++ b/x/arkeo/configs/config_values.go
@@ -19,6 +19,7 @@ const (
 	OpenContractCost
 	MinProviderBond
 	ReserveTax
+	AffilateFee
 	BlocksPerYear
 	EmissionCurve
 	ValidatorPayoutCycle
@@ -34,6 +35,7 @@ var nameToString = map[ConfigName]string{
 	OpenContractCost:           "OpenContractCost",
 	MinProviderBond:            "MinProviderBond",
 	ReserveTax:                 "ReserveTax",
+	AffilateFee:                "AffilateFee",
 	BlocksPerYear:              "BlocksPerYear",
 	EmissionCurve:              "EmissionCurve",
 	ValidatorPayoutCycle:       "ValidatorPayoutCycle",

--- a/x/arkeo/keeper/msg_server_open_contract.go
+++ b/x/arkeo/keeper/msg_server_open_contract.go
@@ -144,6 +144,7 @@ func (k msgServer) OpenContractHandle(ctx cosmos.Context, msg *types.MsgOpenCont
 		Paid:               cosmos.ZeroInt(),
 		Height:             ctx.BlockHeight(),
 		SettlementDuration: msg.SettlementDuration,
+		Affiliate:          msg.Affiliate,
 	}
 
 	// create expiration set

--- a/x/arkeo/types/events.go
+++ b/x/arkeo/types/events.go
@@ -32,6 +32,7 @@ func NewOpenContractEvent(openCost int64, contract *Contract) sdk.Event {
 		sdk.NewAttribute("open_cost", strconv.FormatInt(openCost, 10)),
 		sdk.NewAttribute("deposit", contract.Deposit.String()),
 		sdk.NewAttribute("settlement_duration", strconv.FormatInt(contract.SettlementDuration, 10)),
+		sdk.NewAttribute("affiliate", contract.Affiliate.String()),
 	)
 }
 

--- a/x/arkeo/types/message_open_contract.go
+++ b/x/arkeo/types/message_open_contract.go
@@ -15,7 +15,7 @@ const TypeMsgOpenContract = "open_contract"
 
 var _ sdk.Msg = &MsgOpenContract{}
 
-func NewMsgOpenContract(creator string, provider common.PubKey, service string, client, delegate common.PubKey, contractType ContractType, duration, settlementDuration int64, rate types.Coin, deposit cosmos.Int) *MsgOpenContract {
+func NewMsgOpenContract(creator string, provider common.PubKey, service string, client, delegate common.PubKey, contractType ContractType, duration, settlementDuration int64, rate types.Coin, deposit cosmos.Int, affiliate cosmos.AccAddress) *MsgOpenContract {
 	return &MsgOpenContract{
 		Creator:            creator,
 		Provider:           provider,
@@ -27,6 +27,7 @@ func NewMsgOpenContract(creator string, provider common.PubKey, service string, 
 		Deposit:            deposit,
 		Delegate:           delegate,
 		SettlementDuration: settlementDuration,
+		Affiliate:          affiliate,
 	}
 }
 


### PR DESCRIPTION
This allows a contract to be opened with an affiliate address. This affiliate address will cause 90% of the income to go to the data provider, 5% to the reserve and 5% to the affiliate. If there is no affiliate, 10% of the income goes to the reserve