### PR TITLE
tweak emission curve

### DIFF
--- a/test/regression/mnt/exports/suites_contracts_pay-as-you-go.json
+++ b/test/regression/mnt/exports/suites_contracts_pay-as-you-go.json
@@ -14,6 +14,7 @@
       ],
       "contracts": [
         {
+          "authorization": "STRICT",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "100",
@@ -23,6 +24,7 @@
           "nonce": "1",
           "paid": "3",
           "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
+          "queries_per_minute": "0",
           "rate": {
             "amount": "3",
             "denom": "uarkeo"
@@ -247,7 +249,7 @@
           "address": "tarkeo1d0m97ywk2y4vq58ud6q5e0r3q9khj9e3unfe4t",
           "coins": [
             {
-              "amount": "99999980",
+              "amount": "99999988",
               "denom": "uarkeo"
             }
           ]
@@ -274,7 +276,7 @@
           "address": "tarkeo1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyvls9rz",
           "coins": [
             {
-              "amount": "20",
+              "amount": "12",
               "denom": "uarkeo"
             }
           ]

--- a/test/regression/mnt/exports/suites_contracts_pay-as-you-go.json
+++ b/test/regression/mnt/exports/suites_contracts_pay-as-you-go.json
@@ -14,7 +14,6 @@
       ],
       "contracts": [
         {
-          "authorization": "STRICT",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "100",
@@ -24,7 +23,6 @@
           "nonce": "1",
           "paid": "3",
           "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
-          "queries_per_minute": "0",
           "rate": {
             "amount": "3",
             "denom": "uarkeo"

--- a/test/regression/mnt/exports/suites_contracts_subscription.json
+++ b/test/regression/mnt/exports/suites_contracts_subscription.json
@@ -22,7 +22,6 @@
       ],
       "contracts": [
         {
-          "authorization": "STRICT",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "100",
@@ -32,7 +31,6 @@
           "nonce": "0",
           "paid": "100",
           "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
-          "queries_per_minute": "0",
           "rate": {
             "amount": "10",
             "denom": "uarkeo"
@@ -43,7 +41,6 @@
           "type": "SUBSCRIPTION"
         },
         {
-          "authorization": "STRICT",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "20",
@@ -53,7 +50,6 @@
           "nonce": "0",
           "paid": "20",
           "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
-          "queries_per_minute": "0",
           "rate": {
             "amount": "10",
             "denom": "uarkeo"

--- a/test/regression/mnt/exports/suites_contracts_subscription.json
+++ b/test/regression/mnt/exports/suites_contracts_subscription.json
@@ -22,6 +22,7 @@
       ],
       "contracts": [
         {
+          "authorization": "STRICT",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "100",
@@ -31,6 +32,7 @@
           "nonce": "0",
           "paid": "100",
           "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
+          "queries_per_minute": "0",
           "rate": {
             "amount": "10",
             "denom": "uarkeo"
@@ -41,6 +43,7 @@
           "type": "SUBSCRIPTION"
         },
         {
+          "authorization": "STRICT",
           "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
           "delegate": "",
           "deposit": "20",
@@ -50,6 +53,7 @@
           "nonce": "0",
           "paid": "20",
           "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
+          "queries_per_minute": "0",
           "rate": {
             "amount": "10",
             "denom": "uarkeo"
@@ -262,7 +266,7 @@
           "address": "tarkeo1d0m97ywk2y4vq58ud6q5e0r3q9khj9e3unfe4t",
           "coins": [
             {
-              "amount": "199999912",
+              "amount": "199999952",
               "denom": "uarkeo"
             }
           ]
@@ -280,7 +284,7 @@
           "address": "tarkeo1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyvls9rz",
           "coins": [
             {
-              "amount": "100",
+              "amount": "60",
               "denom": "uarkeo"
             }
           ]

--- a/x/arkeo/configs/config_v1.go
+++ b/x/arkeo/configs/config_v1.go
@@ -17,7 +17,7 @@ func NewConfigValue010() *ConfigVals {
 			MinProviderBond:            common.Tokens(1),           // min bond for a data provider to be able to open contracts with
 			ReserveTax:                 1000,                       // reserve income off provider income, in basis points
 			BlocksPerYear:              5256666,                    // blocks per year
-			EmissionCurve:              4,                          // rate in which the reserve is depleted to pay validators
+			EmissionCurve:              6,                          // rate in which the reserve is depleted to pay validators
 			ValidatorPayoutCycle:       1,                          // how often validators are paid out rewards
 		},
 		boolValues:   map[ConfigName]bool{},

--- a/x/arkeo/keeper/manager_test.go
+++ b/x/arkeo/keeper/manager_test.go
@@ -86,42 +86,42 @@ func TestValidatorPayout(t *testing.T) {
 	mgr := NewManager(k, sk)
 	ctx = ctx.WithBlockHeight(mgr.FetchConfig(ctx, configs.ValidatorPayoutCycle))
 
-	blockReward := int64(237792)
+	blockReward := int64(158529)
 	require.NoError(t, mgr.ValidatorEndBlock(ctx))
 	require.Equal(t, k.GetBalanceOfModule(ctx, types.ReserveName, configs.Denom).Int64(), 5000000000000-blockReward)
 
 	// check validator balances
 	totalBal := cosmos.ZeroInt()
 	bal := k.GetBalance(ctx, acc1)
-	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(27984))
+	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(18657))
 	totalBal = totalBal.Add(bal.AmountOf(configs.Denom))
-	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(27984))
+	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(18657))
 
 	bal = k.GetBalance(ctx, acc2)
-	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(55962))
+	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(37308))
 	totalBal = totalBal.Add(bal.AmountOf(configs.Denom))
-	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(55962))
+	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(37308))
 
 	bal = k.GetBalance(ctx, acc3)
-	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(139878))
+	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(93252))
 	totalBal = totalBal.Add(bal.AmountOf(configs.Denom))
-	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(139878))
+	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(93252))
 
 	// check delegate balances
 	bal = k.GetBalance(ctx, delAcc1)
-	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(2795))
+	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(1863))
 	totalBal = totalBal.Add(bal.AmountOf(configs.Denom))
-	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(2795))
+	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(1863))
 
 	bal = k.GetBalance(ctx, delAcc2)
-	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(5589))
+	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(3726))
 	totalBal = totalBal.Add(bal.AmountOf(configs.Denom))
-	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(5589))
+	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(3726))
 
 	bal = k.GetBalance(ctx, delAcc3)
-	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(5584))
+	require.Equal(t, bal.AmountOf(configs.Denom).Int64(), int64(3723))
 	totalBal = totalBal.Add(bal.AmountOf(configs.Denom))
-	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(5584))
+	require.Equal(t, bal.AmountOf("tokkie").Int64(), int64(3723))
 
 	// ensure block reward is equal to total rewarded to validators and delegates
 	require.Equal(t, blockReward, totalBal.Int64())


### PR DESCRIPTION
tweaking the emission curve from a 4 --> 6, which reduces the rate of block emissions. Yield for validators/delegates will be less but the reserve will last longer. From memory, a value of 6 creates a similar emission schedule as Bitcoin (but continuous instead halving every 4 years)