### PR TITLE
remove gaia archive override

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,6 @@ services:
       FREE_RATE_LIMIT: 10
       FREE_RATE_LIMIT_DURATION: "1m"
       CLAIM_STORE_LOCATION: "/root/.arkeo/claims"
-      GAIA_RPC_ARCHIVE_HOST: "http://176.34.207.130:26657"
     entrypoint: "/scripts/sentinel.sh"
     command: sentinel
     volumes:

--- a/infra/k8s/sentinel-config.yaml
+++ b/infra/k8s/sentinel-config.yaml
@@ -19,4 +19,3 @@ data:
   AS_GO_RATE_LIMIT: "60"
   AS_GO_RATE_LIMIT_DURATION: "1m"
   CLAIM_STORE_LOCATION: "/root/.arkeo/claims"
-  GAIA_RPC_ARCHIVE_HOST: "http://10.10.3.26:26657"

--- a/sentinel/conf/configuration.go
+++ b/sentinel/conf/configuration.go
@@ -21,7 +21,6 @@ type Configuration struct {
 	ClaimStoreLocation string        `json:"claim_store_location"` // file location where claims are stored
 	ProviderPubKey     common.PubKey `json:"provider_pubkey"`
 	FreeTierRateLimit  int           `json:"free_tier_rate_limit"`
-	GaiaRpcArchiveHost string        `json:"gaia_rpc_archive_host"`
 }
 
 // Simple helper function to read an environment or return a default value
@@ -76,7 +75,6 @@ func NewConfiguration() Configuration {
 		ProviderPubKey:     loadVarPubKey("PROVIDER_PUBKEY"),
 		FreeTierRateLimit:  loadVarInt("FREE_RATE_LIMIT"),
 		ClaimStoreLocation: loadVarString("CLAIM_STORE_LOCATION"),
-		GaiaRpcArchiveHost: loadVarString("GAIA_RPC_ARCHIVE_HOST"),
 	}
 }
 

--- a/sentinel/conf/configuration_test.go
+++ b/sentinel/conf/configuration_test.go
@@ -18,7 +18,6 @@ func TestConfiguration(t *testing.T) {
 	os.Setenv("PROVIDER_PUBKEY", "cosmospub1addwnpepqg3523h7e7ggeh6na2lsde6s394tqxnvufsz0urld6zwl8687ue9c3dasgu")
 	os.Setenv("FREE_RATE_LIMIT", "99")
 	os.Setenv("CLAIM_STORE_LOCATION", "clammy")
-	os.Setenv("GAIA_RPC_ARCHIVE_HOST", "gaia-host")
 
 	config := NewConfiguration()
 

--- a/sentinel/event_stream_test.go
+++ b/sentinel/event_stream_test.go
@@ -30,7 +30,6 @@ func newTestConfig() conf.Configuration {
 		ProviderPubKey:     types.GetRandomPubKey(),
 		FreeTierRateLimit:  100,
 		ClaimStoreLocation: "",
-		GaiaRpcArchiveHost: "gaia-host",
 	}
 }
 

--- a/sentinel/sentinel.go
+++ b/sentinel/sentinel.go
@@ -58,12 +58,9 @@ func loadProxies() map[string]*url.URL {
 		// parse default values for services
 		switch serviceName {
 		case "btc-mainnet-fullnode", "bch-mainnet-fullnode", "doge-mainnet-fullnode", "ltc-mainnet-fullnode":
-			// add username/password to request
-			uri := fmt.Sprintf("http://infra:password@%s:8332", serviceName)
-			proxies[serviceName] = common.MustParseURL(uri)
+			proxies[serviceName] = common.MustParseURL(fmt.Sprintf("http://infra:password@%s:8332", serviceName))
 		case "arkeo-mainnet-fullnode":
-			uri := "http://arkeod:1317"
-			proxies[serviceName] = common.MustParseURL(uri)
+			proxies[serviceName] = common.MustParseURL("http://arkeod:1317")
 		case "swapi.dev":
 			proxies[serviceName] = common.MustParseURL(fmt.Sprintf("https://%s", serviceName))
 		default:

--- a/test/regression/cmd/run.go
+++ b/test/regression/cmd/run.go
@@ -268,7 +268,6 @@ func run(path string) error {
 		"EVENT_STREAM_HOST=localhost:26657",
 		"FREE_RATE_LIMIT=10",
 		"CLAIM_STORE_LOCATION=/regtest/.arkeo/claims",
-		"GAIA_RPC_ARCHIVE_HOST=http://176.34.207.130:26657",
 	)
 	stderr, err = sentinel.StderrPipe()
 	if err != nil {


### PR DESCRIPTION
this manual hack for supporting gaia archive node was put in for phase 1 testing and should be removed at this point for phase 2. Need to make sure people are testing the infra of arkeo rather than some other system remotely (although there is a way to proxy requests to another server externally)