### PR TITLE
contract restrictions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       FREE_RATE_LIMIT: 10
       FREE_RATE_LIMIT_DURATION: "1m"
       CLAIM_STORE_LOCATION: "/root/.arkeo/claims"
+      CONTRACT_CONFIG_STORE_LOCATION: "/root/.arkeo/contract_configs"
     entrypoint: "/scripts/sentinel.sh"
     command: sentinel
     volumes:

--- a/sentinel/conf/configuration.go
+++ b/sentinel/conf/configuration.go
@@ -11,16 +11,17 @@ import (
 )
 
 type Configuration struct {
-	Moniker            string        `json:"moniker"`
-	Website            string        `json:"website"`
-	Description        string        `json:"description"`
-	Location           string        `json:"location"`
-	Port               string        `json:"port"`
-	SourceChain        string        `json:"source_chain"` // base url for arceo block chain
-	EventStreamHost    string        `json:"event_stream_host"`
-	ClaimStoreLocation string        `json:"claim_store_location"` // file location where claims are stored
-	ProviderPubKey     common.PubKey `json:"provider_pubkey"`
-	FreeTierRateLimit  int           `json:"free_tier_rate_limit"`
+	Moniker                     string        `json:"moniker"`
+	Website                     string        `json:"website"`
+	Description                 string        `json:"description"`
+	Location                    string        `json:"location"`
+	Port                        string        `json:"port"`
+	SourceChain                 string        `json:"source_chain"` // base url for arceo block chain
+	EventStreamHost             string        `json:"event_stream_host"`
+	ClaimStoreLocation          string        `json:"claim_store_location"`           // file location where claims are stored
+	ContractConfigStoreLocation string        `json:"contract_config_store_location"` // file location where contract configurations are stored
+	ProviderPubKey              common.PubKey `json:"provider_pubkey"`
+	FreeTierRateLimit           int           `json:"free_tier_rate_limit"`
 }
 
 // Simple helper function to read an environment or return a default value
@@ -65,16 +66,17 @@ func loadVarInt(key string) int {
 
 func NewConfiguration() Configuration {
 	return Configuration{
-		Moniker:            loadVarString("MONIKER"),
-		Website:            loadVarString("WEBSITE"),
-		Description:        loadVarString("DESCRIPTION"),
-		Location:           loadVarString("LOCATION"),
-		Port:               getEnv("PORT", "3636"),
-		SourceChain:        loadVarString("SOURCE_CHAIN"),
-		EventStreamHost:    loadVarString("EVENT_STREAM_HOST"),
-		ProviderPubKey:     loadVarPubKey("PROVIDER_PUBKEY"),
-		FreeTierRateLimit:  loadVarInt("FREE_RATE_LIMIT"),
-		ClaimStoreLocation: loadVarString("CLAIM_STORE_LOCATION"),
+		Moniker:                     loadVarString("MONIKER"),
+		Website:                     loadVarString("WEBSITE"),
+		Description:                 loadVarString("DESCRIPTION"),
+		Location:                    loadVarString("LOCATION"),
+		Port:                        getEnv("PORT", "3636"),
+		SourceChain:                 loadVarString("SOURCE_CHAIN"),
+		EventStreamHost:             loadVarString("EVENT_STREAM_HOST"),
+		ProviderPubKey:              loadVarPubKey("PROVIDER_PUBKEY"),
+		FreeTierRateLimit:           loadVarInt("FREE_RATE_LIMIT"),
+		ClaimStoreLocation:          loadVarString("CLAIM_STORE_LOCATION"),
+		ContractConfigStoreLocation: loadVarString("CONTRACT_CONFIG_STORE_LOCATION"),
 	}
 }
 
@@ -89,6 +91,7 @@ func (c Configuration) Print() {
 	fmt.Fprintln(writer, "Event Stream Host\t", c.EventStreamHost)
 	fmt.Fprintln(writer, "Provider PubKey\t", c.ProviderPubKey)
 	fmt.Fprintln(writer, "Claim Store Location\t", c.ClaimStoreLocation)
+	fmt.Fprintln(writer, "Contract Config Store Location\t", c.ContractConfigStoreLocation)
 	fmt.Fprintln(writer, "Free Tier Rate Limit\t", fmt.Sprintf("%d requests per 1m", c.FreeTierRateLimit))
 	writer.Flush()
 }

--- a/sentinel/conf/configuration_test.go
+++ b/sentinel/conf/configuration_test.go
@@ -18,6 +18,7 @@ func TestConfiguration(t *testing.T) {
 	os.Setenv("PROVIDER_PUBKEY", "cosmospub1addwnpepqg3523h7e7ggeh6na2lsde6s394tqxnvufsz0urld6zwl8687ue9c3dasgu")
 	os.Setenv("FREE_RATE_LIMIT", "99")
 	os.Setenv("CLAIM_STORE_LOCATION", "clammy")
+	os.Setenv("CONTRACT_CONFIG_STORE_LOCATION", "configy")
 
 	config := NewConfiguration()
 
@@ -30,4 +31,5 @@ func TestConfiguration(t *testing.T) {
 	require.Equal(t, config.ProviderPubKey.String(), "cosmospub1addwnpepqg3523h7e7ggeh6na2lsde6s394tqxnvufsz0urld6zwl8687ue9c3dasgu")
 	require.Equal(t, config.FreeTierRateLimit, 99)
 	require.Equal(t, config.ClaimStoreLocation, "clammy")
+	require.Equal(t, config.ContractConfigStoreLocation, "configy")
 }

--- a/sentinel/contract_store.go
+++ b/sentinel/contract_store.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -166,8 +165,4 @@ func (s *ContractConfigurationStore) Close() error {
 
 func (s *ContractConfigurationStore) GetInternalDb() *leveldb.DB {
 	return s.db
-}
-
-func getTimeStamp() int64 {
-	return time.Now().UnixNano()
 }

--- a/sentinel/contract_store.go
+++ b/sentinel/contract_store.go
@@ -1,0 +1,173 @@
+package sentinel
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+type ContractConfigurationStore struct {
+	logger zerolog.Logger
+	db     *leveldb.DB
+}
+
+type CORs struct {
+	AllowOrigins []string `json:"allow_origins"`
+	AllowMethods []string `json:"allow_methods"`
+	AllowHeaders []string `json:"allow_headers"`
+}
+
+func NewCORs() CORs {
+	return CORs{
+		AllowOrigins: make([]string, 0),
+		AllowMethods: make([]string, 0),
+		AllowHeaders: make([]string, 0),
+	}
+}
+
+type ContractConfiguration struct {
+	ContractId           uint64   `json:"contract_id"`
+	LastTimeStamp        int64    `json:"last_timestamp"`
+	PerUserRateLimit     int      `json:"per_user_rate_limit"`
+	CORs                 CORs     `json:"cors"`
+	WhitelistIPAddresses []string `json:"white_listed_ip_addresses"`
+}
+
+func (c ContractConfiguration) Key() string {
+	return strconv.FormatUint(c.ContractId, 10)
+}
+
+type ContractConfigurations []ContractConfiguration
+
+func NewContractConfiguration(contractId uint64, cors CORs, ips []string, rateLimit int) ContractConfiguration {
+	return ContractConfiguration{
+		ContractId:           contractId,
+		LastTimeStamp:        0,
+		CORs:                 cors,
+		WhitelistIPAddresses: ips,
+		PerUserRateLimit:     rateLimit,
+	}
+}
+
+func NewContractConfigurationStore(levelDbFolder string) (*ContractConfigurationStore, error) {
+	var db *leveldb.DB
+	var err error
+	if len(levelDbFolder) == 0 {
+		log.Warn().Msg("level db folder is empty, create in memory storage")
+		// no directory given, use in memory store
+		storage := storage.NewMemStorage()
+		db, err = leveldb.Open(storage, nil)
+		if err != nil {
+			return nil, fmt.Errorf("fail to in memory open level db: %w", err)
+		}
+	} else {
+		db, err = leveldb.OpenFile(levelDbFolder, nil)
+		if err != nil {
+			return nil, fmt.Errorf("fail to open level db %s: %w", levelDbFolder, err)
+		}
+	}
+	return &ContractConfigurationStore{
+		logger: log.With().Str("module", "contract-config-storage").Logger(),
+		db:     db,
+	}, nil
+}
+
+func (s *ContractConfigurationStore) Set(item ContractConfiguration) error {
+	key := item.Key()
+	buf, err := json.Marshal(item)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("fail to marshal to claim store item")
+		return err
+	}
+	if err := s.db.Put([]byte(key), buf, nil); err != nil {
+		s.logger.Error().Err(err).Msg("fail to set claim item")
+		return err
+	}
+	return nil
+}
+
+func (s *ContractConfigurationStore) Batch(items ContractConfigurations) error {
+	batch := new(leveldb.Batch)
+	for _, item := range items {
+		key := item.Key()
+		buf, err := json.Marshal(item)
+		if err != nil {
+			s.logger.Error().Err(err).Msg("fail to marshal to contract configuration store item")
+			return err
+		}
+		batch.Put([]byte(key), buf)
+	}
+	return s.db.Write(batch, nil)
+}
+
+func (s *ContractConfigurationStore) Get(id uint64) (item ContractConfiguration, err error) {
+	item = NewContractConfiguration(id, NewCORs(), make([]string, 0), 0)
+	key := item.Key()
+	ok, err := s.db.Has([]byte(key), nil)
+	if !ok || err != nil {
+		return
+	}
+	buf, err := s.db.Get([]byte(key), nil)
+	if err := json.Unmarshal(buf, &item); err != nil {
+		s.logger.Error().Err(err).Msg("fail to unmarshal to contract configuration store item")
+		return item, err
+	}
+
+	return
+}
+
+// Has check whether the given key exist in key value store
+func (s *ContractConfigurationStore) Has(id uint64) (ok bool) {
+	key := strconv.FormatUint(id, 10)
+	ok, _ = s.db.Has([]byte(key), nil)
+	return
+}
+
+// Remove remove the given item from key values store
+func (s *ContractConfigurationStore) Remove(id uint64) error {
+	key := strconv.FormatUint(id, 10)
+	return s.db.Delete([]byte(key), nil)
+}
+
+// List send back tx out to retry depending on arg failed only
+func (s *ContractConfigurationStore) List() ContractConfigurations {
+	iterator := s.db.NewIterator(util.BytesPrefix([]byte(nil)), nil)
+	defer iterator.Release()
+	var results ContractConfigurations
+	for iterator.Next() {
+		buf := iterator.Value()
+		if len(buf) == 0 {
+			continue
+		}
+
+		var item ContractConfiguration
+		if err := json.Unmarshal(buf, &item); err != nil {
+			s.logger.Error().Err(err).Msg("fail to unmarshal to contract configuration store item")
+			continue
+		}
+
+		results = append(results, item)
+	}
+
+	return results
+}
+
+// Close underlying db
+func (s *ContractConfigurationStore) Close() error {
+	return s.db.Close()
+}
+
+func (s *ContractConfigurationStore) GetInternalDb() *leveldb.DB {
+	return s.db
+}
+
+func getTimeStamp() int64 {
+	return time.Now().UnixNano()
+}

--- a/sentinel/routes.go
+++ b/sentinel/routes.go
@@ -5,5 +5,6 @@ const (
 	RoutesActiveContract = "/active-contract/"
 	RoutesClaim          = "/claim/"
 	RoutesOpenClaims     = "/open-claims/"
+	RouteManage          = "/manage/contract/"
 	RoutesDefault        = "/"
 )

--- a/sentinel/sentinel.go
+++ b/sentinel/sentinel.go
@@ -179,6 +179,12 @@ func (p Proxy) handleContract(w http.ResponseWriter, r *http.Request) {
 			respondWithError(w, fmt.Sprintf("bad contract auth: %s", err), http.StatusBadRequest)
 			return
 		}
+		conf.LastTimeStamp = auth.Timestamp
+		if err := p.ContractConfigStore.Set(conf); err != nil {
+			p.logger.Error("fail to save contract config", "error", err, "auth", auth.String())
+			respondWithError(w, fmt.Sprintf("fail to save contract config: %s", err), http.StatusBadRequest)
+			return
+		}
 	} else {
 		p.logger.Error("missing contract auth")
 		respondWithError(w, fmt.Sprintf("missing contract auth: %s", err), http.StatusBadRequest)

--- a/test/regression/cmd/run.go
+++ b/test/regression/cmd/run.go
@@ -268,6 +268,7 @@ func run(path string) error {
 		"EVENT_STREAM_HOST=localhost:26657",
 		"FREE_RATE_LIMIT=10",
 		"CLAIM_STORE_LOCATION=/regtest/.arkeo/claims",
+		"CONTRACT_CONFIG_STORE_LOCATION=/regtest/.arkeo/contract_configs",
 	)
 	stderr, err = sentinel.StderrPipe()
 	if err != nil {

--- a/test/regression/cmd/template.go
+++ b/test/regression/cmd/template.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"text/template"
+	"time"
 )
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -60,6 +61,9 @@ var funcMap = template.FuncMap{
 	},
 	"addr_module_reserve": func() string {
 		return ModuleAddrReserve
+	},
+	"timestamp": func() int64 {
+		return time.Now().UnixNano()
 	},
 }
 

--- a/test/regression/mnt/exports/suites_sentinel_contract_config.json
+++ b/test/regression/mnt/exports/suites_sentinel_contract_config.json
@@ -1,0 +1,636 @@
+{
+  "app_hash": "",
+  "app_state": {
+    "arkeo": {
+      "contract_expiration_sets": [],
+      "contracts": [
+        {
+          "authorization": "STRICT",
+          "client": "tarkeopub1addwnpepq2res6tu0m73ulk5sepgp6g3y37schfgymxy8z6l3lc78k7ju9u45yajwem",
+          "delegate": "",
+          "deposit": "100",
+          "duration": "1000000000000",
+          "height": "1",
+          "id": "1",
+          "nonce": "0",
+          "paid": "0",
+          "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
+          "queries_per_minute": "100",
+          "rate": {
+            "amount": "1",
+            "denom": "uarkeo"
+          },
+          "service": 1,
+          "settlement_duration": "0",
+          "settlement_height": "0",
+          "type": "SUBSCRIPTION"
+        },
+        {
+          "authorization": "STRICT",
+          "client": "tarkeopub1addwnpepqwqyxlhy8jkhmcw56augeewn9mmg32e93ljnnwyd3sjrgmsz499rqg360pk",
+          "delegate": "",
+          "deposit": "100",
+          "duration": "1000000000000",
+          "height": "1",
+          "id": "2",
+          "nonce": "0",
+          "paid": "0",
+          "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
+          "queries_per_minute": "100",
+          "rate": {
+            "amount": "1",
+            "denom": "uarkeo"
+          },
+          "service": 1,
+          "settlement_duration": "0",
+          "settlement_height": "0",
+          "type": "SUBSCRIPTION"
+        },
+        {
+          "authorization": "STRICT",
+          "client": "tarkeopub1addwnpepqv26g6avmnhfkr4a2ds03mj36kuanmua5d95xwelypkd936hea5eyhzg6hd",
+          "delegate": "",
+          "deposit": "100",
+          "duration": "1000000000000",
+          "height": "1",
+          "id": "3",
+          "nonce": "0",
+          "paid": "0",
+          "provider": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
+          "queries_per_minute": "100",
+          "rate": {
+            "amount": "1",
+            "denom": "uarkeo"
+          },
+          "service": 1,
+          "settlement_duration": "0",
+          "settlement_height": "0",
+          "type": "SUBSCRIPTION"
+        }
+      ],
+      "next_contract_id": "0",
+      "params": {},
+      "providers": [
+        {
+          "bond": "1000000000000",
+          "last_update": "1",
+          "max_contract_duration": "10",
+          "metadata_nonce": "0",
+          "metadata_uri": "localhost:3636",
+          "min_contract_duration": "3",
+          "pay_as_you_go_rate": [
+            {
+              "amount": "3",
+              "denom": "uarkeo"
+            }
+          ],
+          "pub_key": "tarkeopub1addwnpepqtsg8syrpcn60t2nnvnhtk6psr8qxlrtwjk8rmpkhxk9vy9wkd8ewmqv7rh",
+          "service": 1,
+          "settlement_duration": "0",
+          "status": "ONLINE",
+          "subscription_rate": [
+            {
+              "amount": "10",
+              "denom": "uarkeo"
+            }
+          ]
+        }
+      ],
+      "user_contract_sets": []
+    },
+    "auth": {
+      "accounts": [
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "account_number": "5",
+            "address": "tarkeo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3e79s43",
+            "pub_key": null,
+            "sequence": "0"
+          },
+          "name": "bonded_tokens_pool",
+          "permissions": [
+            "burner",
+            "staking"
+          ]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "account_number": "6",
+            "address": "tarkeo1tygms3xhhs3yv487phx3dw4a95jn7t7ld7epr9",
+            "pub_key": null,
+            "sequence": "0"
+          },
+          "name": "not_bonded_tokens_pool",
+          "permissions": [
+            "burner",
+            "staking"
+          ]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "account_number": "2",
+          "address": "tarkeo1v0n7wer498vqq6yddkr4clg3lck7kaw9lstp4k",
+          "pub_key": null,
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "account_number": "7",
+            "address": "tarkeo10d07y265gmmuvt4z0w9aw880jnsr700jk8l664",
+            "pub_key": null,
+            "sequence": "0"
+          },
+          "name": "gov",
+          "permissions": [
+            "burner"
+          ]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "account_number": "4",
+            "address": "tarkeo1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8t6gr9e",
+            "pub_key": null,
+            "sequence": "0"
+          },
+          "name": "distribution",
+          "permissions": []
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "account_number": "0",
+          "address": "tarkeo1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyvls9rz",
+          "pub_key": {
+            "@type": "/cosmos.crypto.secp256k1.PubKey",
+            "key": "AxWka6zc7psOvVNg+O5R1bnZ752jS0M7PyBs0sdXz2mS"
+          },
+          "sequence": "1"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "account_number": "8",
+            "address": "tarkeo1m3h30wlvsf8llruxtpukdvsy0km2kum8y5t8tx",
+            "pub_key": null,
+            "sequence": "0"
+          },
+          "name": "mint",
+          "permissions": [
+            "minter"
+          ]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "account_number": "1",
+          "address": "tarkeo1uhapc6jjq6ns0ydnk7zld5x7f5kl2ukemjw5fg",
+          "pub_key": null,
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "account_number": "3",
+            "address": "tarkeo17xpfvakm2amg962yls6f84z3kell8c5luu0l8m",
+            "pub_key": null,
+            "sequence": "0"
+          },
+          "name": "fee_collector",
+          "permissions": []
+        }
+      ],
+      "params": {
+        "max_memo_characters": "256",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10"
+      }
+    },
+    "authz": {
+      "authorization": []
+    },
+    "bank": {
+      "balances": [
+        {
+          "address": "tarkeo1rcvm4v5mcepj53fh2526uve0tly4grdsx5yw7k",
+          "coins": [
+            {
+              "amount": "1000000000000",
+              "denom": "uarkeo"
+            }
+          ]
+        },
+        {
+          "address": "tarkeo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3e79s43",
+          "coins": [
+            {
+              "amount": "50000000000000000",
+              "denom": "uarkeo"
+            }
+          ]
+        },
+        {
+          "address": "tarkeo1v0n7wer498vqq6yddkr4clg3lck7kaw9lstp4k",
+          "coins": [
+            {
+              "amount": "1000000000000000",
+              "denom": "uarkeo"
+            }
+          ]
+        },
+        {
+          "address": "tarkeo1kz2dkl8zlxwte008astc5e65htrxdcse6x3h3h",
+          "coins": [
+            {
+              "amount": "300",
+              "denom": "uarkeo"
+            }
+          ]
+        },
+        {
+          "address": "tarkeo1uhapc6jjq6ns0ydnk7zld5x7f5kl2ukemjw5fg",
+          "coins": [
+            {
+              "amount": "1000000000000000",
+              "denom": "uarkeo"
+            }
+          ]
+        },
+        {
+          "address": "tarkeo17xpfvakm2amg962yls6f84z3kell8c5luu0l8m",
+          "coins": [
+            {
+              "amount": "1071077891",
+              "denom": "stake"
+            }
+          ]
+        }
+      ],
+      "denom_metadata": [],
+      "params": {
+        "default_send_enabled": true,
+        "send_enabled": []
+      },
+      "supply": [
+        {
+          "amount": "1071077891",
+          "denom": "stake"
+        },
+        {
+          "amount": "52001000000000300",
+          "denom": "uarkeo"
+        }
+      ]
+    },
+    "capability": {
+      "index": "3",
+      "owners": [
+        {
+          "index": "1",
+          "index_owners": {
+            "owners": [
+              {
+                "module": "ibc",
+                "name": "ports/transfer"
+              },
+              {
+                "module": "transfer",
+                "name": "ports/transfer"
+              }
+            ]
+          }
+        },
+        {
+          "index": "2",
+          "index_owners": {
+            "owners": [
+              {
+                "module": "ibc",
+                "name": "ports/icahost"
+              },
+              {
+                "module": "icahost",
+                "name": "ports/icahost"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "claimarkeo": {
+      "claim_records": [],
+      "module_account_balance": {
+        "amount": "0",
+        "denom": "uarkeo"
+      },
+      "params": {
+        "claim_denom": "uarkeo",
+        "duration_of_decay": "3600s",
+        "duration_until_decay": "3600s",
+        "initial_gas_amount": null
+      }
+    },
+    "crisis": {
+      "constant_fee": {
+        "amount": "1000",
+        "denom": "stake"
+      }
+    },
+    "distribution": {
+      "delegator_starting_infos": [
+        {
+          "delegator_address": "tarkeo1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyvls9rz",
+          "starting_info": {
+            "height": "0",
+            "previous_period": "1",
+            "stake": "50000000000000000.000000000000000000"
+          },
+          "validator_address": "tarkeovaloper1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyfn54sh"
+        }
+      ],
+      "delegator_withdraw_infos": [],
+      "fee_pool": {
+        "community_pool": []
+      },
+      "outstanding_rewards": [
+        {
+          "outstanding_rewards": [],
+          "validator_address": "tarkeovaloper1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyfn54sh"
+        }
+      ],
+      "params": {
+        "base_proposer_reward": "0.010000000000000000",
+        "bonus_proposer_reward": "0.040000000000000000",
+        "community_tax": "0.020000000000000000",
+        "withdraw_addr_enabled": true
+      },
+      "previous_proposer": "tarkeovalcons1tjy86luccxcq0d76ntqcpkaeuehnca5qjfnfpa",
+      "validator_accumulated_commissions": [
+        {
+          "accumulated": {
+            "commission": []
+          },
+          "validator_address": "tarkeovaloper1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyfn54sh"
+        }
+      ],
+      "validator_current_rewards": [
+        {
+          "rewards": {
+            "period": "2",
+            "rewards": []
+          },
+          "validator_address": "tarkeovaloper1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyfn54sh"
+        }
+      ],
+      "validator_historical_rewards": [
+        {
+          "period": "1",
+          "rewards": {
+            "cumulative_reward_ratio": [],
+            "reference_count": 2
+          },
+          "validator_address": "tarkeovaloper1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyfn54sh"
+        }
+      ],
+      "validator_slash_events": []
+    },
+    "evidence": {
+      "evidence": []
+    },
+    "feegrant": {
+      "allowances": []
+    },
+    "genutil": {
+      "gen_txs": []
+    },
+    "gov": {
+      "deposit_params": {
+        "max_deposit_period": "172800s",
+        "min_deposit": [
+          {
+            "amount": "10000000",
+            "denom": "stake"
+          }
+        ]
+      },
+      "deposits": [],
+      "proposals": [],
+      "starting_proposal_id": "1",
+      "tally_params": {
+        "quorum": "0.334000000000000000",
+        "threshold": "0.500000000000000000",
+        "veto_threshold": "0.334000000000000000"
+      },
+      "votes": [],
+      "voting_params": {
+        "voting_period": "172800s"
+      }
+    },
+    "group": {
+      "group_members": [],
+      "group_policies": [],
+      "group_policy_seq": "0",
+      "group_seq": "0",
+      "groups": [],
+      "proposal_seq": "0",
+      "proposals": [],
+      "votes": []
+    },
+    "ibc": {
+      "channel_genesis": {
+        "ack_sequences": [],
+        "acknowledgements": [],
+        "channels": [],
+        "commitments": [],
+        "next_channel_sequence": "0",
+        "receipts": [],
+        "recv_sequences": [],
+        "send_sequences": []
+      },
+      "client_genesis": {
+        "clients": [],
+        "clients_consensus": [],
+        "clients_metadata": [],
+        "create_localhost": false,
+        "next_client_sequence": "0",
+        "params": {
+          "allowed_clients": [
+            "06-solomachine",
+            "07-tendermint"
+          ]
+        }
+      },
+      "connection_genesis": {
+        "client_connection_paths": [],
+        "connections": [],
+        "next_connection_sequence": "0",
+        "params": {
+          "max_expected_time_per_block": "30000000000"
+        }
+      }
+    },
+    "interchainaccounts": {
+      "controller_genesis_state": {
+        "active_channels": [],
+        "interchain_accounts": [],
+        "params": {
+          "controller_enabled": true
+        },
+        "ports": []
+      },
+      "host_genesis_state": {
+        "active_channels": [],
+        "interchain_accounts": [],
+        "params": {
+          "allow_messages": [],
+          "host_enabled": true
+        },
+        "port": "icahost"
+      }
+    },
+    "mint": {
+      "minter": {
+        "annual_provisions": "6760129533969267.126114311412635100",
+        "inflation": "0.129999991038042117"
+      },
+      "params": {
+        "blocks_per_year": "6311520",
+        "goal_bonded": "0.670000000000000000",
+        "inflation_max": "0.200000000000000000",
+        "inflation_min": "0.070000000000000000",
+        "inflation_rate_change": "0.130000000000000000",
+        "mint_denom": "stake"
+      }
+    },
+    "params": null,
+    "slashing": {
+      "missed_blocks": [
+        {
+          "address": "tarkeovalcons1tjy86luccxcq0d76ntqcpkaeuehnca5qjfnfpa",
+          "missed_blocks": []
+        }
+      ],
+      "params": {
+        "downtime_jail_duration": "600s",
+        "min_signed_per_window": "0.500000000000000000",
+        "signed_blocks_window": "100",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.010000000000000000"
+      },
+      "signing_infos": [
+        {
+          "address": "tarkeovalcons1tjy86luccxcq0d76ntqcpkaeuehnca5qjfnfpa",
+          "validator_signing_info": {
+            "address": "tarkeovalcons1tjy86luccxcq0d76ntqcpkaeuehnca5qjfnfpa",
+            "index_offset": "0",
+            "jailed_until": "1970-01-01T00:00:00Z",
+            "missed_blocks_counter": "0",
+            "start_height": "0",
+            "tombstoned": false
+          }
+        }
+      ]
+    },
+    "staking": {
+      "delegations": [
+        {
+          "delegator_address": "tarkeo1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyvls9rz",
+          "shares": "50000000000000000.000000000000000000",
+          "validator_address": "tarkeovaloper1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyfn54sh"
+        }
+      ],
+      "exported": true,
+      "last_total_power": "50000000000",
+      "last_validator_powers": [
+        {
+          "address": "tarkeovaloper1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyfn54sh",
+          "power": "50000000000"
+        }
+      ],
+      "params": {
+        "bond_denom": "uarkeo",
+        "historical_entries": 10000,
+        "max_entries": 7,
+        "max_validators": 100,
+        "min_commission_rate": "0.000000000000000000",
+        "unbonding_time": "1814400s"
+      },
+      "redelegations": [],
+      "unbonding_delegations": [],
+      "validators": [
+        {
+          "commission": {
+            "commission_rates": {
+              "max_change_rate": "0.010000000000000000",
+              "max_rate": "0.200000000000000000",
+              "rate": "0.100000000000000000"
+            }
+          },
+          "consensus_pubkey": {
+            "@type": "/cosmos.crypto.ed25519.PubKey",
+            "key": "6ERoG0djS6fNNdNZCezEL8e8aSdffT87d2sJMK5TXVo="
+          },
+          "delegator_shares": "50000000000000000.000000000000000000",
+          "description": {
+            "details": "",
+            "identity": "",
+            "moniker": "local",
+            "security_contact": "",
+            "website": ""
+          },
+          "jailed": false,
+          "min_self_delegation": "1",
+          "operator_address": "tarkeovaloper1hnyy4gp5tgarpg3xu6w5cw4zsyphx2lyfn54sh",
+          "status": "BOND_STATUS_BONDED",
+          "tokens": "50000000000000000",
+          "unbonding_height": "0",
+          "unbonding_time": "1970-01-01T00:00:00Z"
+        }
+      ]
+    },
+    "transfer": {
+      "denom_traces": [],
+      "params": {
+        "receive_enabled": true,
+        "send_enabled": true
+      },
+      "port_id": "transfer"
+    },
+    "upgrade": {},
+    "vesting": {}
+  },
+  "chain_id": "arkeo",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "22020096",
+      "max_gas": "-1",
+      "time_iota_ms": "1000"
+    },
+    "evidence": {
+      "max_age_duration": "172800000000000",
+      "max_age_num_blocks": "100000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    },
+    "version": {}
+  },
+  "initial_height": "2",
+  "validators": [
+    {
+      "address": "5C887D7F98C1B007B7DA9AC180DBB9E66F3C7680",
+      "name": "local",
+      "power": "50000000000",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "6ERoG0djS6fNNdNZCezEL8e8aSdffT87d2sJMK5TXVo="
+      }
+    }
+  ]
+}

--- a/test/regression/suites/sentinel/contract_config.yaml
+++ b/test/regression/suites/sentinel/contract_config.yaml
@@ -43,7 +43,7 @@ description: check metadata.json
 endpoint: http://localhost:3636/manage/contract/1
 contractauth:
   id: "1"
-  timestamp: "10"
+  timestamp: "12"
   signer: "cat"
 status: 200
 asserts:
@@ -71,7 +71,7 @@ method: "POST"
 body: '{"per_user_rate_limit":1,"cors":{"allow_origins":["foo","bar","baz"],"allow_methods":["meth1", "meth2", "meth3"],"allow_headers":["head1", "head2", "head3"]},"white_listed_ip_addresses":[]}'
 contractauth:
   id: "1"
-  timestamp: "12"
+  timestamp: "13"
   signer: "cat"
 status: 200
 ---
@@ -118,7 +118,7 @@ method: "POST"
 body: '{"per_user_rate_limit":100,"cors":{"allow_origins":["foo","bar","baz"],"allow_methods":["meth1", "meth2", "meth3"],"allow_headers":["head1", "head2", "head3"]},"white_listed_ip_addresses":["ip1", "ip2", "ip3"]}'
 contractauth:
   id: "1"
-  timestamp: "13"
+  timestamp: "14"
   signer: "cat"
 status: 200
 ---

--- a/test/regression/suites/sentinel/contract_config.yaml
+++ b/test/regression/suites/sentinel/contract_config.yaml
@@ -1,0 +1,137 @@
+{{ template "default-state.yaml" }}
+---
+{{ template "provider.yaml" }}
+---
+{{ template "contract.yaml" }}
+---
+type: create-blocks
+count: 1
+---
+########################################################################################
+# fetch contract configuration
+########################################################################################
+type: check
+description: check metadata.json
+endpoint: http://localhost:3636/manage/contract/1
+contractauth:
+  id: "1"
+  timestamp: "10"
+  signer: "cat"
+status: 200
+asserts:
+  - .per_user_rate_limit == 0
+---
+########################################################################################
+# update contract configuration
+########################################################################################
+type: check
+description: check tier header
+endpoint: http://localhost:3636/manage/contract/1
+method: "POST"
+body: '{"per_user_rate_limit":100,"cors":{"allow_origins":["foo","bar","baz"],"allow_methods":["meth1", "meth2", "meth3"],"allow_headers":["head1", "head2", "head3"]},"white_listed_ip_addresses":["ip1", "ip2", "ip3"]}'
+contractauth:
+  id: "1"
+  timestamp: "11"
+  signer: "cat"
+status: 200
+---
+########################################################################################
+# check that contract configuration has been updated
+########################################################################################
+type: check
+description: check metadata.json
+endpoint: http://localhost:3636/manage/contract/1
+contractauth:
+  id: "1"
+  timestamp: "10"
+  signer: "cat"
+status: 200
+asserts:
+  - .per_user_rate_limit == 100
+  - .white_listed_ip_addresses[0] == "ip1"
+  - .white_listed_ip_addresses[1] == "ip2"
+  - .white_listed_ip_addresses[2] == "ip3"
+  - .cors.allow_origins[0] == "foo"
+  - .cors.allow_origins[1] == "bar"
+  - .cors.allow_origins[2] == "baz"
+  - .cors.allow_methods[0] == "meth1"
+  - .cors.allow_methods[1] == "meth2"
+  - .cors.allow_methods[2] == "meth3"
+  - .cors.allow_headers[0] == "head1"
+  - .cors.allow_headers[1] == "head2"
+  - .cors.allow_headers[2] == "head3"
+---
+########################################################################################
+# update contract configuration, test CORs and per user rate limit
+########################################################################################
+type: check
+description: check tier header
+endpoint: http://localhost:3636/manage/contract/1
+method: "POST"
+body: '{"per_user_rate_limit":1,"cors":{"allow_origins":["foo","bar","baz"],"allow_methods":["meth1", "meth2", "meth3"],"allow_headers":["head1", "head2", "head3"]},"white_listed_ip_addresses":[]}'
+contractauth:
+  id: "1"
+  timestamp: "12"
+  signer: "cat"
+status: 200
+---
+########################################################################################
+# check CORs
+########################################################################################
+type: check
+description: check tier header
+endpoint: http://localhost:3636/swapi.dev/api/people/1
+arkauth:
+  signer: cat
+  id: "1"
+  spender: {{ pubkey_cat }}
+  nonce: "1"
+headers:
+  Tier: "paid"
+  Access-Control-Allow-Origin: "foo, bar, baz"
+  Access-Control-Allow-Methods: "meth1, meth2, meth3"
+  Access-Control-Allow-Headers: "head1, head2, head3"
+status: 200
+asserts:
+  - .name == "Luke Skywalker"
+---
+########################################################################################
+# check per user rate limit
+########################################################################################
+type: check
+description: check tier header
+endpoint: http://localhost:3636/swapi.dev/api/people/1
+arkauth:
+  signer: cat
+  id: "1"
+  spender: {{ pubkey_cat }}
+  nonce: "1"
+status: 429
+---
+########################################################################################
+# update contract configuration to test IP white listing
+########################################################################################
+type: check
+description: check tier header
+endpoint: http://localhost:3636/manage/contract/1
+method: "POST"
+body: '{"per_user_rate_limit":100,"cors":{"allow_origins":["foo","bar","baz"],"allow_methods":["meth1", "meth2", "meth3"],"allow_headers":["head1", "head2", "head3"]},"white_listed_ip_addresses":["ip1", "ip2", "ip3"]}'
+contractauth:
+  id: "1"
+  timestamp: "13"
+  signer: "cat"
+status: 200
+---
+########################################################################################
+# check CORs
+########################################################################################
+type: check
+description: check tier header
+endpoint: http://localhost:3636/swapi.dev/api/people/1
+arkauth:
+  signer: cat
+  id: "1"
+  spender: {{ pubkey_cat }}
+  nonce: "1"
+status: 403
+---

--- a/test/regression/templates/contract.yaml
+++ b/test/regression/templates/contract.yaml
@@ -1,0 +1,53 @@
+type: state
+genesis:
+  app_state:
+    bank:
+      balances:
+        - address: {{ addr_module_contract }}
+          coins:
+            - amount: "300"
+              denom: uarkeo
+    arkeo:
+      contracts:
+        - provider: {{ pubkey_fox }}
+          service: 1
+          client: {{ pubkey_cat }}
+          type: 0
+          height: 1
+          duration: 1000000000000
+          rate: 
+            denom: "uarkeo"
+            amount: "1"
+          deposit: "100"
+          paid: "0"
+          id: "1"
+          authorization: 0
+          queries_per_minute: 100
+        - provider: {{ pubkey_fox }}
+          service: 1
+          client: {{ pubkey_pig }}
+          type: 1
+          height: 1
+          duration: 1000000000000
+          rate: 
+            denom: "uarkeo"
+            amount: "1"
+          deposit: "100"
+          paid: "0"
+          id: "2"
+          authorization: 1
+          queries_per_minute: 100
+        - provider: {{ pubkey_fox }}
+          service: 1
+          client: {{ pubkey_dog }}
+          type: 1
+          height: 1
+          duration: 1000000000000
+          rate: 
+            denom: "uarkeo"
+            amount: "1"
+          deposit: "100"
+          paid: "0"
+          id: "3"
+          authorization: 0
+          queries_per_minute: 100


### PR DESCRIPTION
This adds the ability for a contract owner to configure a contract to have restrictions. Each time they read/write (GET/POST) a contract configuration, its has to be signed in the `contractauth` query arg, using this string format
```
<contract id>:<timestamp>
```
timestamp is the current epoch. Can be in seconds, milliseconds, etc

Contract owners can set the following
 * per user rate limit
 * whitelisted IP list
 * CORs (allowed origins, methods or headers)

These configurations can be done by hitting sentinel at the following uri
```
http://<ip address>:3636/manage/contract/<id>?=contractauth=<id>:<timestamp>:<signature>
```