### PR TITLE
add websocket support for sentinel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ coverage-report: test-coverage
 	@go tool cover -html=coverage.txt
 
 tools:
-	go install ${BUILD_FLAGS} ./tools/signhere ./tools/curleo
+	go install ${BUILD_FLAGS} ./tools/signhere ./tools/curleo ./tools/mock-daemon
 
 test-coverage-sum:
 	@go run gotest.tools/gotestsum --junitfile report.xml --format testname -- ${TEST_BUILD_FLAGS} -v -coverprofile=coverage.txt -covermode count ${TEST_DIR}
@@ -124,6 +124,7 @@ test-regression-coverage:
 # internal target used in docker build
 _build-test-regression:
 	@go install -ldflags '$(ldflags)' -tags=testnet,regtest ${BINARIES}
+	@go install ${BUILD_FLAGS} ./tools/mock-daemon
 	@go build -ldflags '$(ldflags)' -cover -tags=testnet,regtest -o /regtest/cover-arkeod ./cmd/arkeod
 	@go build -ldflags '$(ldflags)' -cover -tags=testnet,regtest -o /regtest/cover-sentinel ./cmd/sentinel
 	@go build -ldflags '$(ldflags)' -cover -tags=testnet,regtest -o /regtest/cover-directory-api ./cmd/directory/directory-api

--- a/common/chain_test.go
+++ b/common/chain_test.go
@@ -13,11 +13,11 @@ func TestService(t *testing.T) {
 	require.False(t, service.IsEmpty())
 	require.Equal(t, service.String(), "btc-mainnet-fullnode")
 
-	service, err = NewService("swapi.dev")
+	service, err = NewService("mock")
 	require.NoError(t, err)
-	require.True(t, service.Equals(StarWarsService))
+	require.True(t, service.Equals(MockService))
 	require.False(t, service.IsEmpty())
-	require.Equal(t, service.String(), "swapi.dev")
+	require.Equal(t, service.String(), "mock")
 
 	_, err = NewService("B") // invalid
 	require.Error(t, err)

--- a/common/service.go
+++ b/common/service.go
@@ -11,15 +11,15 @@ type (
 )
 
 const (
-	EmptyService    Service = iota
-	StarWarsService Service = 1
-	BTCService      Service = 10
-	ETHService      Service = 20
+	EmptyService Service = iota
+	MockService  Service = 1
+	BTCService   Service = 10
+	ETHService   Service = 20
 )
 
 var ServiceLookup = map[string]int32{
 	"unknown":                      0,
-	"swapi.dev":                    1, // star wars API for development purposes
+	"mock":                         1, // mock service for development purposes
 	"arkeo-mainnet-fullnode":       2,
 	"avax-mainnet-fullnode":        3,
 	"avax-mainnet-archivenode":     4,
@@ -67,7 +67,7 @@ var ServiceLookup = map[string]int32{
 
 var ServiceReverseLookup = map[Service]string{
 	0:  "unknown",
-	1:  "swapi.dev",
+	1:  "mock",
 	2:  "arkeo-mainnet-fullnode",
 	3:  "avax-mainnet-fullnode",
 	4:  "avax-mainnet-archivenode",

--- a/common/service_test.go
+++ b/common/service_test.go
@@ -9,8 +9,8 @@ import (
 func TestString(t *testing.T) {
 	var service Service = 0
 	require.Equal(t, "unknown", service.String())
-	service = StarWarsService
-	require.Equal(t, "swapi.dev", service.String())
+	service = MockService
+	require.Equal(t, "mock", service.String())
 	service = BTCService
 	require.Equal(t, "btc-mainnet-fullnode", service.String())
 	service = ETHService

--- a/directory/utils/utils.go
+++ b/directory/utils/utils.go
@@ -53,7 +53,7 @@ func IsNearEqual(a, b, epsilon float64) bool {
 }
 
 // see arkeo-protocol/common/service.go
-var validServices = map[string]struct{}{"arkeo-mainnet-fullnode": {}, "btc-mainnet-fullnode": {}, "eth-mainnet-fullnode": {}, "gaia-mainnet-rpc-archive": {}, "swapi.dev": {}}
+var validServices = map[string]struct{}{"arkeo-mainnet-fullnode": {}, "btc-mainnet-fullnode": {}, "eth-mainnet-fullnode": {}, "gaia-mainnet-rpc-archive": {}, "mock": {}}
 
 func ValidateService(service string) (ok bool) {
 	_, ok = validServices[service]

--- a/go.mod
+++ b/go.mod
@@ -156,6 +156,7 @@ require (
 	github.com/jpillora/sizestr v1.0.0 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
+	github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c // indirect
 	github.com/lib/pq v1.10.6 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1005,6 +1005,8 @@ github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHU
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c h1:N7A4JCA2G+j5fuFxCsJqjFU/sZe0mj8H0sSoSwbaikw=
+github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c/go.mod h1:Nn5wlyECw3iJrzi0AhIWg+AJUb4PlRQVW4/3XHH1LZA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/test/regression/cmd/run.go
+++ b/test/regression/cmd/run.go
@@ -309,6 +309,12 @@ func run(path string) error {
 			sigkill: syscall.SIGKILL,
 		},
 		{
+			name:    "mock",
+			cmd:     []string{"mock-daemon"},
+			ports:   []string{"3765"},
+			sigkill: syscall.SIGKILL,
+		},
+		{
 			name:  "directory-api",
 			cmd:   []string{"directory-api"},
 			ports: []string{"7777"},

--- a/test/regression/suites/contracts/pay-as-you-go.yaml
+++ b/test/regression/suites/contracts/pay-as-you-go.yaml
@@ -12,7 +12,7 @@ type: tx-open-contract
 signer: {{ addr_cat }}
 creator: {{ addr_cat }}
 provider: {{ pubkey_fox }}
-service: "swapi.dev"
+service: "mock"
 client: {{ pubkey_cat }}
 contract_type: "PAY_AS_YOU_GO"
 queries_per_minute: 1
@@ -69,7 +69,7 @@ asserts:
 ########################################################################################
 type: check
 description: check can make paid request
-endpoint: http://localhost:3636/swapi.dev/api/people/1
+endpoint: http://localhost:3636/mock/ping
 arkauth:
   signer: cat
   id: "1"
@@ -77,7 +77,7 @@ arkauth:
 assert_headers:
   Tier: "paid"
 asserts:
-  - .name == "Luke Skywalker"
+  - .ping == "pong"
 ---
 type: create-blocks
 count: 1
@@ -87,7 +87,7 @@ count: 1
 ########################################################################################
 type: check
 description: ensure contract shows up in active contracts
-endpoint: http://localhost:3636/active-contract/swapi.dev/{{ pubkey_cat }}
+endpoint: http://localhost:3636/active-contract/mock/{{ pubkey_cat }}
 asserts:
   - .contract.provider == "{{ pubkey_fox }}"
   - .contract.service == 1

--- a/test/regression/suites/contracts/subscription.yaml
+++ b/test/regression/suites/contracts/subscription.yaml
@@ -12,7 +12,7 @@ type: tx-open-contract
 signer: {{ addr_cat }}
 creator: {{ addr_cat }}
 provider: {{ pubkey_fox }}
-service: "swapi.dev"
+service: "mock"
 client: {{ pubkey_cat }}
 contract_type: "SUBSCRIPTION"
 queries_per_minute: 1
@@ -57,7 +57,7 @@ asserts:
   - .rate.amount == "10"
   - .rate.denom == "uarkeo"
   - .provider == "{{ pubkey_fox }}"
-  - .service == "swapi.dev"
+  - .service == "mock"
 ---
 type: check
 description: cat account balance should decrease
@@ -71,9 +71,9 @@ asserts:
 ########################################################################################
 type: check
 description: check can make paid request
-endpoint: http://localhost:3636/api/people/1
+endpoint: http://localhost:3636/ping
 headers:
-  arkservice: swapi.dev
+  arkservice: mock
 arkauth:
   signer: cat
   id: "1"
@@ -82,7 +82,7 @@ arkauth:
 assert_headers:
   Tier: "paid"
 asserts:
-  - .name == "Luke Skywalker"
+  - .ping == "pong"
 ---
 ########################################################################################
 # check subscription settles okay
@@ -122,7 +122,7 @@ type: tx-open-contract
 signer: {{ addr_cat }}
 creator: {{ addr_cat }}
 provider: {{ pubkey_fox }}
-service: "swapi.dev"
+service: "mock"
 client: {{ pubkey_cat }}
 contract_type: "SUBSCRIPTION"
 queries_per_minute: 1
@@ -165,14 +165,14 @@ asserts:
 ########################################################################################
 type: check
 description: check can make paid request
-endpoint: http://localhost:3636/swapi.dev/api/people/1
+endpoint: http://localhost:3636/mock/ping
 arkauth:
   id: "2"
   nosig: "true"
 assert_headers:
   Tier: "paid"
 asserts:
-  - .name == "Luke Skywalker"
+  - .ping == "pong"
 ---
 ########################################################################################
 # cancel subscription with bad address

--- a/test/regression/suites/sentinel/contract_config.yaml
+++ b/test/regression/suites/sentinel/contract_config.yaml
@@ -80,7 +80,7 @@ status: 200
 ########################################################################################
 type: check
 description: check tier header
-endpoint: http://localhost:3636/swapi.dev/api/people/1
+endpoint: http://localhost:3636/mock/ping
 arkauth:
   signer: cat
   id: "1"
@@ -93,14 +93,14 @@ headers:
   Access-Control-Allow-Headers: "head1, head2, head3"
 status: 200
 asserts:
-  - .name == "Luke Skywalker"
+  - .ping == "pong"
 ---
 ########################################################################################
 # check per user rate limit
 ########################################################################################
 type: check
 description: check tier header
-endpoint: http://localhost:3636/swapi.dev/api/people/1
+endpoint: http://localhost:3636/mock/ping
 arkauth:
   signer: cat
   id: "1"
@@ -127,7 +127,7 @@ status: 200
 ########################################################################################
 type: check
 description: check tier header
-endpoint: http://localhost:3636/swapi.dev/api/people/1
+endpoint: http://localhost:3636/mock/ping
 arkauth:
   signer: cat
   id: "1"

--- a/test/regression/suites/sentinel/sentinel.yaml
+++ b/test/regression/suites/sentinel/sentinel.yaml
@@ -17,9 +17,16 @@ asserts:
 ########################################################################################
 type: check
 description: check tier header
-endpoint: http://localhost:3636/swapi.dev/api/people/1
+endpoint: http://localhost:3636/mock/ping
 headers:
   Tier: "free"
 status: 200
 asserts:
-  - .name == "Luke Skywalker"
+  - .ping == "pong"
+---
+########################################################################################
+# check websockets work
+########################################################################################
+type: check-websocket
+description: check websocket connection
+endpoint: ws://localhost:3636/mock/ws

--- a/tools/mock-daemon/main.go
+++ b/tools/mock-daemon/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+func serveWs(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer conn.Close()
+
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			log.Println("read:", err)
+			break
+		}
+		log.Printf("received: %s", msg)
+
+		err = conn.WriteMessage(websocket.TextMessage, []byte("pong"))
+		if err != nil {
+			log.Println("write:", err)
+			break
+		}
+	}
+}
+
+func serveHttp(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("{\"ping\": \"pong\"}"))
+}
+
+func main() {
+	http.HandleFunc("/ws", serveWs)
+	http.HandleFunc("/ping", serveHttp)
+
+	srv := &http.Server{
+		Handler:      http.DefaultServeMux,
+		Addr:         "127.0.0.1:3765",
+		WriteTimeout: 15 * time.Second,
+		ReadTimeout:  15 * time.Second,
+	}
+
+	log.Fatal(srv.ListenAndServe())
+}


### PR DESCRIPTION
Fixes #110 

This adds the ability for sentinel to support websocket requests. Accounting/billing is being punted on to refactor another day. Current proposal is disable websockets access for free tier and pay-as-you-go requests.

This PR also removes the utilization of swapi.dev from regression tests. Instead a new mock daemon is created to run tests against. This was done because we needed something that supports websockets (star wars didn't support it), and also keeps integration tests local (good for in-flight coding)