### PR TITLE
replace dash with underscore

### DIFF
--- a/sentinel/sentinel.go
+++ b/sentinel/sentinel.go
@@ -60,7 +60,7 @@ func loadProxies() map[string]*url.URL {
 	for serviceName := range common.ServiceLookup {
 		// if we have an override for a given service, parse that instead of
 		// the default below
-		env, envOk := os.LookupEnv(strings.ToUpper(serviceName))
+		env, envOk := os.LookupEnv(strings.ToUpper(strings.ReplaceAll(serviceName, "-", "_")))
 		if envOk {
 			proxies[serviceName] = common.MustParseURL(env)
 			continue


### PR DESCRIPTION
kubernetes doesn't allow env vars with dashes in the name. Because of this, switching the lookup with underscores.