### PR TITLE
Add claim records for localnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,11 @@ lint:
 	@go build ${BINARIES}
 	@./scripts/trunk check --no-fix --upstream origin/master
 
+lint-fix:
+	@./scripts/lint.sh
+	@go build ${BINARIES}
+	@./scripts/trunk check --upstream origin/master
+
 lint-ci:
 	@./scripts/lint.sh
 	@go build ${BINARIES}

--- a/app/app.go
+++ b/app/app.go
@@ -184,6 +184,7 @@ var (
 		stakingtypes.NotBondedPoolName: {authtypes.Burner, authtypes.Staking},
 		govtypes.ModuleName:            {authtypes.Burner},
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
+		claimmoduletypes.ModuleName:    {authtypes.Minter},
 		arkeomoduletypes.ModuleName:    {},
 		arkeomoduletypes.ReserveName:   {},
 		arkeomoduletypes.ProviderName:  {},

--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -827,12 +827,8 @@ paths:
           type: string
         - name: chain
           in: query
-          required: false
-          type: string
-          enum:
-            - ARKEO
-            - ETHEREUM
-          default: ARKEO
+          required: true
+          type: integer
       tags:
         - Query
   /arkeo/claim/params:

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -76,6 +76,7 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 
 	if [ "$NET" = "mocknet" ] || [ "$NET" = "testnet" ]; then
 		add_module tarkeo1d0m97ywk2y4vq58ud6q5e0r3q9khj9e3unfe4t $TOKEN 10000000000000000 'arkeo-reserve' # reserve, 100m
+		add_module tarkeo14tmx70mvve3u7hfmd45vle49kvylk6s2wllxny $TOKEN 10000000000000000 'claimarkeo' # reserve, 100m
 
 		echo "shoulder heavy loyal save patient deposit crew bag pull club escape eyebrow hip verify border into wire start pact faint fame festival solve shop" | arkeod keys add alice --keyring-backend test --recover
 		ALICE=$(arkeod keys show alice -a --keyring-backend test)
@@ -85,8 +86,9 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 		BOB=$(arkeod keys show bob -a --keyring-backend test)
 		add_account "$BOB" $TOKEN 1000000000000000 # bob, 10m
 
-		add_claim_records "ARKEO" "$BOB" 1000000000000000 1000000000000000 1000000000000000 true
-		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 5000000000000000 1000000000000000 1000000000000000 true
+		add_claim_records "ARKEO" "tarkeo19rhn0qgk227zxv8475arky0fhhhy9n9dh6nrj9" 500000 500000 500000 true
+		add_claim_records "ARKEO" "$BOB" 1000 1000 1000 true
+		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 500000 500000 500000 true
 
 		# enable CORs on testnet/localnet
 		sed -i 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/g' ~/.arkeo/config/app.toml

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -45,6 +45,18 @@ add_account() {
 	mv /tmp/genesis.json ~/.arkeo/config/genesis.json
 }
 
+add_claim_records() {
+	jq --arg CHAIN "$1" --arg ADDRESS "$2" --arg AMOUNTCLAIM "$3" --arg AMOUNTVOTE "$4" --arg AMOUNTDELEGATE "$5" --arg ISTRANSFERABLE "$6" '.app_state.claimarkeo.claim_records += [{
+        "chain": $CHAIN,
+		"address": $ADDRESS,
+        "amount_claim": { "denom": "uarkeo", "amount": $AMOUNTCLAIM },
+        "amount_vote": { "denom": "uarkeo", "amount": $AMOUNTVOTE },
+        "amount_delegate": { "denom": "uarkeo", "amount": $AMOUNTDELEGATE },
+        "is_transferable": true,
+    }]' <~/.arkeo/config/genesis.json >/tmp/genesis.json
+	mv /tmp/genesis.json ~/.arkeo/config/genesis.json
+}
+
 if [ ! -f ~/.arkeo/config/priv_validator_key.json ]; then
 	# remove the original generate genesis file, as below will init chain again
 	rm -rf ~/.arkeo/config/genesis.json
@@ -72,6 +84,9 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 		echo "clog swear steak glide artwork glory solution short company borrow aerobic idle corn climb believe wink forum destroy miracle oak cover solid valve make" | arkeod keys add bob --keyring-backend test --recover
 		BOB=$(arkeod keys show bob -a --keyring-backend test)
 		add_account "$BOB" $TOKEN 1000000000000000 # bob, 10m
+
+		add_claim_records "ARKEO" "$BOB" 1000000000000000 1000000000000000 1000000000000000 true
+		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 5000000000000000 1000000000000000 1000000000000000 true
 	fi
 
 	sed -i 's/"stake"/"uarkeo"/g' ~/.arkeo/config/genesis.json

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -93,9 +93,6 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 		add_claim_records "ARKEO" "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" 500000 500000 500000 true
 		add_account "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" $TOKEN 1000000000000000 
 		
-		add_account "tarkeo1xfpnvwphxyeyydfjxu652veegyuygsjpxppnqsesxsu5xv2px3pngveegserg33saudhje" $TOKEN 1000000000000000 
-		add_claim_records "ARKEO" "tarkeo1xfpnvwphxyeyydfjxu652veegyuygsjpxppnqsesxsu5xv2px3pngveegserg33saudhje" 500000 500000 500000 true
-
 		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 500000 600000 700000 true
 
 		# enable CORs on testnet/localnet

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -89,7 +89,7 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 
 		# add_claim_records "ARKEO" "{YOUR ARKEO ADDRESS}" 500000 500000 500000 true
 		# add_account "{YOUR ARKEO ADDRESS}" $TOKEN 1000000000000000
-		
+
 		# add_claim_records "ETHEREUM" "{YOUR ETH ADDRESS}" 500000 600000 700000 true
 
 		# enable CORs on testnet/localnet

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -85,14 +85,22 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 		echo "clog swear steak glide artwork glory solution short company borrow aerobic idle corn climb believe wink forum destroy miracle oak cover solid valve make" | arkeod keys add bob --keyring-backend test --recover
 		BOB=$(arkeod keys show bob -a --keyring-backend test)
 		add_account "$BOB" $TOKEN 1000000000000000 # bob, 10m
+		add_claim_records "ARKEO" "$BOB" 1000 1000 1000 true
 
 		add_claim_records "ARKEO" "tarkeo19rhn0qgk227zxv8475arky0fhhhy9n9dh6nrj9" 500000 500000 500000 true
-		add_claim_records "ARKEO" "$BOB" 1000 1000 1000 true
-		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 500000 500000 500000 true
+		add_account "tarkeo19rhn0qgk227zxv8475arky0fhhhy9n9dh6nrj9" $TOKEN 1000000000000000 
+
+		add_claim_records "ARKEO" "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" 500000 500000 500000 true
+		add_account "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" $TOKEN 1000000000000000 
+		
+		add_account "tarkeo1xfpnvwphxyeyydfjxu652veegyuygsjpxppnqsesxsu5xv2px3pngveegserg33saudhje" $TOKEN 1000000000000000 
+		add_claim_records "ARKEO" "tarkeo1xfpnvwphxyeyydfjxu652veegyuygsjpxppnqsesxsu5xv2px3pngveegserg33saudhje" 500000 500000 500000 true
+
+		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 500000 600000 700000 true
 
 		# enable CORs on testnet/localnet
 		sed -i 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/g' ~/.arkeo/config/app.toml
-
+		sed -i 's/cors_allowed_origins = \[\]/cors_allowed_origins = \["*"\]/g' ~/.arkeo/config/config.toml
 	fi
 
 	sed -i 's/"stake"/"uarkeo"/g' ~/.arkeo/config/genesis.json

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -76,7 +76,7 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 
 	if [ "$NET" = "mocknet" ] || [ "$NET" = "testnet" ]; then
 		add_module tarkeo1d0m97ywk2y4vq58ud6q5e0r3q9khj9e3unfe4t $TOKEN 10000000000000000 'arkeo-reserve' # reserve, 100m
-		add_module tarkeo14tmx70mvve3u7hfmd45vle49kvylk6s2wllxny $TOKEN 10000000000000000 'claimarkeo' # reserve, 100m
+		add_module tarkeo14tmx70mvve3u7hfmd45vle49kvylk6s2wllxny $TOKEN 10000000000000000 'claimarkeo'
 
 		echo "shoulder heavy loyal save patient deposit crew bag pull club escape eyebrow hip verify border into wire start pact faint fame festival solve shop" | arkeod keys add alice --keyring-backend test --recover
 		ALICE=$(arkeod keys show alice -a --keyring-backend test)

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -87,6 +87,10 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 
 		add_claim_records "ARKEO" "$BOB" 1000000000000000 1000000000000000 1000000000000000 true
 		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 5000000000000000 1000000000000000 1000000000000000 true
+
+		# enable CORs on testnet/localnet
+		sed -i 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/g' ~/.arkeo/config/app.toml
+
 	fi
 
 	sed -i 's/"stake"/"uarkeo"/g' ~/.arkeo/config/genesis.json

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -88,10 +88,10 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 		add_claim_records "ARKEO" "$BOB" 1000 1000 1000 true
 
 		add_claim_records "ARKEO" "tarkeo19rhn0qgk227zxv8475arky0fhhhy9n9dh6nrj9" 500000 500000 500000 true
-		add_account "tarkeo19rhn0qgk227zxv8475arky0fhhhy9n9dh6nrj9" $TOKEN 1000000000000000 
+		add_account "tarkeo19rhn0qgk227zxv8475arky0fhhhy9n9dh6nrj9" $TOKEN 1000000000000000
 
 		add_claim_records "ARKEO" "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" 500000 500000 500000 true
-		add_account "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" $TOKEN 1000000000000000 
+		add_account "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" $TOKEN 1000000000000000
 		
 		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 500000 600000 700000 true
 

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -87,13 +87,10 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 		add_account "$BOB" $TOKEN 1000000000000000 # bob, 10m
 		add_claim_records "ARKEO" "$BOB" 1000 1000 1000 true
 
-		add_claim_records "ARKEO" "tarkeo19rhn0qgk227zxv8475arky0fhhhy9n9dh6nrj9" 500000 500000 500000 true
-		add_account "tarkeo19rhn0qgk227zxv8475arky0fhhhy9n9dh6nrj9" $TOKEN 1000000000000000
-
-		add_claim_records "ARKEO" "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" 500000 500000 500000 true
-		add_account "tarkeo1xrz7z3zwtpc45xm72tpnevuf3wn53re8q4u4nr" $TOKEN 1000000000000000
+		# add_claim_records "ARKEO" "{YOUR ARKEO ADDRESS}" 500000 500000 500000 true
+		# add_account "{YOUR ARKEO ADDRESS}" $TOKEN 1000000000000000
 		
-		add_claim_records "ETHEREUM" "0x92E14917A0508Eb56C90C90619f5F9Adbf49f47d" 500000 600000 700000 true
+		# add_claim_records "ETHEREUM" "{YOUR ETH ADDRESS}" 500000 600000 700000 true
 
 		# enable CORs on testnet/localnet
 		sed -i 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/g' ~/.arkeo/config/app.toml

--- a/scripts/validator.sh
+++ b/scripts/validator.sh
@@ -32,7 +32,6 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 
 	# fetch node id
 	SEED_ID=$(curl -sL "$RPC/status" | jq -r .result.node_info.id)
-	SEEDS="$SEED_ID@$SEED"
 
 	sed -i 's/enable = false/enable = true/g' ~/.arkeo/config/app.toml
 	sed -i 's/127.0.0.1:26657/0.0.0.0:26657/g' ~/.arkeo/config/config.toml

--- a/scripts/validator.sh
+++ b/scripts/validator.sh
@@ -30,9 +30,6 @@ if [ ! -f ~/.arkeo/config/genesis.json ]; then
 	# fetch genesis file from seed node
 	curl -sL "$GENESIS/genesis" | jq '.result.genesis' >~/.arkeo/config/genesis.json
 
-	# fetch node id
-	SEED_ID=$(curl -sL "$RPC/status" | jq -r .result.node_info.id)
-
 	sed -i 's/enable = false/enable = true/g' ~/.arkeo/config/app.toml
 	sed -i 's/127.0.0.1:26657/0.0.0.0:26657/g' ~/.arkeo/config/config.toml
 	sed -i "s/seeds = \"\"/seeds = \"$PEER_ID@$SEED\"/g" ~/.arkeo/config/config.toml

--- a/sentinel/auth.go
+++ b/sentinel/auth.go
@@ -242,7 +242,7 @@ func (p Proxy) auth(next http.Handler) http.Handler {
 			}
 			ser, err := common.NewService(serviceName)
 			if err != nil || ser != contract.Service {
-				http.Error(w, fmt.Sprintf("contract service doesn't match the serivce name in the path: (%d/%d)", ser, contract.Service), http.StatusUnauthorized)
+				http.Error(w, fmt.Sprintf("contract service doesn't match the service name in the path: (%d/%d)", ser, contract.Service), http.StatusUnauthorized)
 				return
 			}
 
@@ -338,7 +338,7 @@ func (p Proxy) paidTier(aa ArkAuth, remoteAddr string) (code int, err error) {
 	}
 
 	if ok := p.isRateLimited(contract.Id, key, int(contract.QueriesPerMinute)); ok {
-		return http.StatusTooManyRequests, fmt.Errorf("client is ratelimited," + http.StatusText(429))
+		return http.StatusTooManyRequests, fmt.Errorf("client is rate limited," + http.StatusText(429))
 	}
 
 	claim.Nonce = aa.Nonce

--- a/test/regression/cmd/config.go
+++ b/test/regression/cmd/config.go
@@ -135,6 +135,7 @@ var httpClient = &http.Client{
 // Module Addresses
 ////////////////////////////////////////////////////////////////////////////////////////
 
+// trunk-ignore-all(golangci-lint/gosec)
 // trunk-ignore-all(gitleaks/generic-api-key)
 
 const (

--- a/test/regression/cmd/config.go
+++ b/test/regression/cmd/config.go
@@ -136,6 +136,7 @@ var httpClient = &http.Client{
 ////////////////////////////////////////////////////////////////////////////////////////
 
 // trunk-ignore-all(gitleaks/generic-api-key)
+// trunk-ignore(trunk/ignore-does-nothing) # Getting weird lint error only on CI and running locally works fine
 // trunk-ignore-all(golangci-lint/gosec)
 const (
 	ModuleAddrBondedTokensPool    = "tarkeo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3e79s43"

--- a/test/regression/cmd/config.go
+++ b/test/regression/cmd/config.go
@@ -135,7 +135,6 @@ var httpClient = &http.Client{
 // Module Addresses
 ////////////////////////////////////////////////////////////////////////////////////////
 
-// trunk-ignore-all(golangci-lint/gosec)
 // trunk-ignore-all(gitleaks/generic-api-key)
 
 const (

--- a/test/regression/cmd/config.go
+++ b/test/regression/cmd/config.go
@@ -135,9 +135,8 @@ var httpClient = &http.Client{
 // Module Addresses
 ////////////////////////////////////////////////////////////////////////////////////////
 
-// trunk-ignore-all(golangci-lint/gosec)
 // trunk-ignore-all(gitleaks/generic-api-key)
-
+// trunk-ignore-all(golangci-lint/gosec)
 const (
 	ModuleAddrBondedTokensPool    = "tarkeo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3e79s43"
 	ModuleAddrNotBondedTokensPool = "tarkeo1tygms3xhhs3yv487phx3dw4a95jn7t7ld7epr9"

--- a/testnet/config/genesis.json
+++ b/testnet/config/genesis.json
@@ -117,7 +117,7 @@
       "index": "1",
       "owners": []
     },
-    "claim": {
+    "claimarkeo": {
       "module_account_balance": {
         "denom": "",
         "amount": "0"

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -89,7 +89,7 @@ func (k Keeper) GetClaimRecord(ctx sdk.Context, addr string, chain types.Chain) 
 	claimRecord := types.ClaimRecord{}
 	err := k.cdc.Unmarshal(bz, &claimRecord)
 	if err != nil {
-		return types.ClaimRecord{}, err
+		return types.ClaimRecord{Chain: chain}, err
 	}
 
 	return claimRecord, nil

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -82,7 +82,7 @@ func (k Keeper) GetClaimRecord(ctx sdk.Context, addr string, chain types.Chain) 
 	prefixStore := prefix.NewStore(store, chainToStorePrefix(chain))
 	addrBytes := []byte(strings.ToLower(addr))
 	if !prefixStore.Has(addrBytes) {
-		return types.ClaimRecord{}, nil
+		return types.ClaimRecord{Chain: chain}, nil
 	}
 	bz := prefixStore.Get(addrBytes)
 

--- a/x/claim/keeper/msg_server_claim_eth.go
+++ b/x/claim/keeper/msg_server_claim_eth.go
@@ -133,10 +133,9 @@ func IsValidClaimSignature(ethAddress, arkeoAdddress, amount, signature string) 
 		return false, fmt.Errorf("invalid signature length: %d", len(sigHex))
 	}
 
-	// if sigHex[crypto.RecoveryIDOffset] != 27 && sigHex[crypto.RecoveryIDOffset] != 28 {
-	// 	return false, fmt.Errorf("invalid recovery id: %d", sigHex[64])
-	// }
-	// sigHex[64] -= 27
+	if sigHex[crypto.RecoveryIDOffset] == 27 || sigHex[crypto.RecoveryIDOffset] == 28 {
+		sigHex[crypto.RecoveryIDOffset] -= 27 // Transform yellow paper V from 27/28 to 0/1
+	}
 
 	pubKeyRaw, err := crypto.Ecrecover(rawDataHash.Bytes(), sigHex)
 	if err != nil {

--- a/x/claim/keeper/query_claim_record_test.go
+++ b/x/claim/keeper/query_claim_record_test.go
@@ -56,5 +56,5 @@ func TestClaimRecord(t *testing.T) {
 		Chain:   types.ETHEREUM,
 	}
 	resp, _ = keepers.ClaimKeeper.ClaimRecord(ctx, &req)
-	require.Equal(t, *resp.ClaimRecord, types.ClaimRecord{})
+	require.Equal(t, *resp.ClaimRecord, types.ClaimRecord{Chain: types.ETHEREUM})
 }


### PR DESCRIPTION
- Fix Eth signature verification
- Fix Claim module not being added to maccPerms
- Fix openApi for claim record query
- Fix error when no claimrecord is shown defaulting to ARKEO chain
- Update genesis.json to be `claimarkeo` instead of `claim`
- Add claimrecords when running testnet/localnet
- typos
- enable CORs for localnet/testnet
- lint
- update tests