### PR TITLE
chore: security issue patch

### DIFF
--- a/sentinel/conf/configuration_test.go
+++ b/sentinel/conf/configuration_test.go
@@ -7,19 +7,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfiguration(t *testing.T) {
+func setupRequiredEnvVars(t *testing.T) {
+	t.Helper()
 	os.Setenv("MONIKER", "monkey")
 	os.Setenv("WEBSITE", "webby")
 	os.Setenv("DESCRIPTION", "dezy")
 	os.Setenv("LOCATION", "locy")
 	os.Setenv("PORT", "4000")
 	os.Setenv("SOURCE_CHAIN", "sourcey")
+	os.Setenv("PROVIDER_HUB_URI", "hubby")
 	os.Setenv("EVENT_STREAM_HOST", "hosty")
 	os.Setenv("PROVIDER_PUBKEY", "cosmospub1addwnpepqg3523h7e7ggeh6na2lsde6s394tqxnvufsz0urld6zwl8687ue9c3dasgu")
 	os.Setenv("FREE_RATE_LIMIT", "99")
 	os.Setenv("CLAIM_STORE_LOCATION", "clammy")
 	os.Setenv("CONTRACT_CONFIG_STORE_LOCATION", "configy")
 	os.Setenv("PROVIDER_CONFIG_STORE_LOCATION", "providy")
+}
+
+func TestConfiguration(t *testing.T) {
+	setupRequiredEnvVars(t)
+	os.Setenv("TRUSTED_PROXY_IPS", "10.0.0.1,192.168.0.0/16,172.16.0.1")
 
 	config := NewConfiguration()
 
@@ -34,4 +41,5 @@ func TestConfiguration(t *testing.T) {
 	require.Equal(t, config.ClaimStoreLocation, "clammy")
 	require.Equal(t, config.ContractConfigStoreLocation, "configy")
 	require.Equal(t, config.ProviderConfigStoreLocation, "providy")
+	require.Equal(t, config.TrustedProxyIPs, []string{"10.0.0.1", "192.168.0.0/16", "172.16.0.1"})
 }

--- a/sentinel/event_stream.go
+++ b/sentinel/event_stream.go
@@ -220,7 +220,7 @@ func (p Proxy) handleCloseContractEvent(result tmCoreTypes.ResultEvent) {
 
 	evt, ok := typedEvent.(*types.EventCloseContract)
 	if !ok {
-		p.logger.Error(fmt.Sprintf("failed to cast %T to EventCloseContract", typedEvent))
+		p.logger.Error("failed to cast to EventCloseContract", "type", fmt.Sprintf("%T", typedEvent))
 		return
 	}
 
@@ -406,12 +406,12 @@ func (p Proxy) handleModProviderEvent(result tmCoreTypes.ResultEvent) {
 		return
 	}
 
-	p.logger.Error(fmt.Sprintf("evt.Provider: ", evt.Provider))
-	p.logger.Error(fmt.Sprintf("service.String(): ", service.String()))
+	p.logger.Error("evt.Provider", "provider", evt.Provider)
+	p.logger.Error("service", "service", service.String())
 
 	providerConfig, err := p.ProviderConfigStore.Get(evt.Provider, service.String())
 	if err != nil {
-		p.logger.Error(fmt.Sprintf("failed to get provider %s", err))
+		p.logger.Error("failed to get provider", "error", err)
 		return
 	}
 


### PR DESCRIPTION
This PR addresses some vulnerabilities within arkeo protocol.
- [x] Prevent IP spoofing
- [x] Impove sentinel auth validation to prevent replay attacks by ensuring timestamp is not too far in the future.
- [x] Prevent double settlement attacks within arkeo module manager
- [x] Remove unncessary DEBUG printing of sensitive information
- [x] Add relevant unit tests to prove the patches working as desired
